### PR TITLE
cog.repl_global_scope: add ext.commands shortcut

### DIFF
--- a/jishaku/cog.py
+++ b/jishaku/cog.py
@@ -53,7 +53,12 @@ class Jishaku:
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self.init_time = time.monotonic()
-        self.repl_global_scope = {}
+        self.repl_global_scope = {
+            "_bot": self.bot,
+            "asyncio": asyncio,
+            "discord": discord,
+            "commands": discord.ext.commands,
+        }
         self.repl_local_scope = {}
 
     def do_later(self, delay: float, coro, *args, **kwargs):
@@ -110,14 +115,6 @@ class Jishaku:
 
         self.jsk.hidden = False
         await ctx.send("Showing self..")
-
-    def prepare_environment(self, ctx: commands.Context):
-        """Update the REPL scope with variables relating to the current ctx"""
-        self.repl_global_scope.update({
-            "_bot": ctx.bot,
-            "asyncio": asyncio,
-            "discord": discord
-        })
 
     @jsk.command(name="python", aliases=["py", "```py"])
     async def python_repl(self, ctx, *, code: str):

--- a/jishaku/cog.py
+++ b/jishaku/cog.py
@@ -120,8 +120,7 @@ class Jishaku:
     async def python_repl(self, ctx, *, code: str):
         """Python REPL-like command
 
-        This evaluates or 
-        utes code passed into it, supporting async syntax.
+        This evaluates or executes code passed into it, supporting async syntax.
         Global variables include _ctx and _bot for interactions.
         """
 

--- a/jishaku/cog.py
+++ b/jishaku/cog.py
@@ -120,7 +120,8 @@ class Jishaku:
     async def python_repl(self, ctx, *, code: str):
         """Python REPL-like command
 
-        This evaluates or executes code passed into it, supporting async syntax.
+        This evaluates or 
+        utes code passed into it, supporting async syntax.
         Global variables include _ctx and _bot for interactions.
         """
 
@@ -170,11 +171,13 @@ class Jishaku:
             coro_format = utils.repl_coro(code)
             code_object = compile(coro_format, '<repl-x session>', 'exec')
 
+        # copy the dicts so that the exec doesn't modify them
+        global_scope, local_scope = self.repl_global_scope.copy(), self.repl_local_scope.copy()
         # our code object is ready, let's actually execute it now
-        exec(code_object, self.repl_global_scope, self.repl_local_scope)
+        exec(code_object, global_scope, local_scope)
 
         # Grab the coro we just defined
-        extracted_coro = self.repl_local_scope.get("__repl_coroutine")
+        extracted_coro = global_scope.get("__repl_coroutine")
 
         result = None
 

--- a/jishaku/cog.py
+++ b/jishaku/cog.py
@@ -171,8 +171,6 @@ class Jishaku:
             code_object = compile(coro_format, '<repl-x session>', 'exec')
 
         # our code object is ready, let's actually execute it now
-        self.prepare_environment(ctx)
-
         exec(code_object, self.repl_global_scope, self.repl_local_scope)
 
         # Grab the coro we just defined


### PR DESCRIPTION
I also removed prepare_environment since it didn't actually use any variables that were unique to ctx.