### PR TITLE
`jishaku hide/show` should also hide/show subcommands

### DIFF
--- a/jishaku/cog.py
+++ b/jishaku/cog.py
@@ -165,7 +165,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
 
         await ctx.send("\n".join(summary))
 
-    @jsk.command(name="hide")
+    @jsk.command(name="hide", hidden=JISHAKU_HIDE)
     async def jsk_hide(self, ctx: commands.Context):
         """
         Hides Jishaku from the help command.
@@ -177,7 +177,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
         self.jsk.hidden = True
         await ctx.send("Jishaku is now hidden.")
 
-    @jsk.command(name="show")
+    @jsk.command(name="show", hidden=JISHAKU_HIDE)
     async def jsk_show(self, ctx: commands.Context):
         """
         Shows Jishaku in the help command.
@@ -191,7 +191,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
 
     __cat_line_regex = re.compile(r"(?:\.\/+)?(.+?)(?:#L?(\d+)(?:\-L?(\d+))?)?$")
 
-    @jsk.command(name="cat")
+    @jsk.command(name="cat", hidden=JISHAKU_HIDE)
     async def jsk_cat(self, ctx: commands.Context, argument: str):
         """
         Read out a file, using syntax highlighting if detected.
@@ -235,7 +235,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
         interface = PaginatorInterface(ctx.bot, paginator, owner=ctx.author)
         await interface.send_to(ctx)
 
-    @jsk.command(name="tasks")
+    @jsk.command(name="tasks", hidden=JISHAKU_HIDE)
     async def jsk_tasks(self, ctx: commands.Context):
         """
         Shows the currently running jishaku tasks.
@@ -253,7 +253,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
         interface = PaginatorInterface(ctx.bot, paginator, owner=ctx.author)
         await interface.send_to(ctx)
 
-    @jsk.command(name="cancel")
+    @jsk.command(name="cancel", hidden=JISHAKU_HIDE)
     async def jsk_cancel(self, ctx: commands.Context, *, index: int):
         """
         Cancels a task with the given index.
@@ -277,7 +277,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
         return await ctx.send(f"Cancelled task {task.index}: `{task.ctx.command.qualified_name}`,"
                               f" invoked at {task.ctx.message.created_at.strftime('%Y-%m-%d %H:%M:%S')} UTC")
 
-    @jsk.command(name="retain")
+    @jsk.command(name="retain", hidden=JISHAKU_HIDE)
     async def jsk_retain(self, ctx: commands.Context, *, toggle: bool):
         """
         Turn variable retention for REPL on or off.
@@ -297,7 +297,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
         self.retain = False
         return await ctx.send("Variable retention is OFF. Future REPL sessions will dispose their scope when done.")
 
-    @jsk.command(name="py", aliases=["python"])
+    @jsk.command(name="py", aliases=["python"], hidden=JISHAKU_HIDE)
     async def jsk_python(self, ctx: commands.Context, *, argument: CodeblockConverter):
         """
         Direct evaluation of Python code.
@@ -344,7 +344,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
 
                             await ctx.send(result.replace(self.bot.http.token, "[token omitted]"))
 
-    @jsk.command(name="py_inspect", aliases=["pyi", "python_inspect", "pythoninspect"])
+    @jsk.command(name="py_inspect", aliases=["pyi", "python_inspect", "pythoninspect"], hidden=JISHAKU_HIDE)
     async def jsk_python_inspect(self, ctx: commands.Context, *, argument: CodeblockConverter):
         """
         Evaluation of Python code with inspect information.
@@ -375,7 +375,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
                     interface = PaginatorInterface(ctx.bot, paginator, owner=ctx.author)
                     await interface.send_to(ctx)
 
-    @jsk.command(name="shell", aliases=["sh"])
+    @jsk.command(name="shell", aliases=["sh"], hidden=JISHAKU_HIDE)
     async def jsk_shell(self, ctx: commands.Context, *, argument: CodeblockConverter):
         """
         Executes statements in the system shell.
@@ -399,7 +399,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
 
                 await interface.add_line(f"\n[status] Return code {reader.close_code}")
 
-    @jsk.command(name="git")
+    @jsk.command(name="git", hidden=JISHAKU_HIDE)
     async def jsk_git(self, ctx: commands.Context, *, argument: CodeblockConverter):
         """
         Shortcut for 'jsk sh git'. Invokes the system shell.
@@ -407,7 +407,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
 
         return await ctx.invoke(self.jsk_shell, argument=Codeblock(argument.language, "git " + argument.content))
 
-    @jsk.command(name="load", aliases=["reload"])
+    @jsk.command(name="load", aliases=["reload"], hidden=JISHAKU_HIDE)
     async def jsk_load(self, ctx: commands.Context, *extensions: ExtensionConverter):
         """
         Loads or reloads the given extension names.
@@ -433,7 +433,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
         for page in paginator.pages:
             await ctx.send(page)
 
-    @jsk.command(name="unload")
+    @jsk.command(name="unload", hidden=JISHAKU_HIDE)
     async def jsk_unload(self, ctx: commands.Context, *extensions: ExtensionConverter):
         """
         Unloads the given extension names.
@@ -456,7 +456,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
         for page in paginator.pages:
             await ctx.send(page)
 
-    @jsk.group(name="voice", aliases=["vc"])
+    @jsk.group(name="voice", aliases=["vc"], hidden=JISHAKU_HIDE)
     @commands.check(vc_check)
     async def jsk_voice(self, ctx: commands.Context):
         """
@@ -478,7 +478,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
         await ctx.send(f"Connected to {voice.channel.name}, "
                        f"{'paused' if voice.is_paused() else 'playing' if voice.is_playing() else 'idle'}.")
 
-    @jsk_voice.command(name="join", aliases=["connect"])
+    @jsk_voice.command(name="join", aliases=["connect"], hidden=JISHAKU_HIDE)
     async def jsk_vc_join(self, ctx: commands.Context, *,
                           destination: typing.Union[discord.VoiceChannel, discord.Member] = None):
         """
@@ -506,7 +506,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
 
         await ctx.send(f"Connected to {destination.name}.")
 
-    @jsk_voice.command(name="disconnect", aliases=["dc"])
+    @jsk_voice.command(name="disconnect", aliases=["dc"], hidden=JISHAKU_HIDE)
     @commands.check(connected_check)
     async def jsk_vc_disconnect(self, ctx: commands.Context):
         """
@@ -518,7 +518,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
         await voice.disconnect()
         await ctx.send(f"Disconnected from {voice.channel.name}.")
 
-    @jsk_voice.command(name="stop")
+    @jsk_voice.command(name="stop", hidden=JISHAKU_HIDE)
     @commands.check(playing_check)
     async def jsk_vc_stop(self, ctx: commands.Context):
         """
@@ -530,7 +530,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
         voice.stop()
         await ctx.send(f"Stopped playing audio in {voice.channel.name}.")
 
-    @jsk_voice.command(name="pause")
+    @jsk_voice.command(name="pause", hidden=JISHAKU_HIDE)
     @commands.check(playing_check)
     async def jsk_vc_pause(self, ctx: commands.Context):
         """
@@ -545,7 +545,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
         voice.pause()
         await ctx.send(f"Paused audio in {voice.channel.name}.")
 
-    @jsk_voice.command(name="resume")
+    @jsk_voice.command(name="resume", hidden=JISHAKU_HIDE)
     @commands.check(playing_check)
     async def jsk_vc_resume(self, ctx: commands.Context):
         """
@@ -560,7 +560,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
         voice.resume()
         await ctx.send(f"Resumed audio in {voice.channel.name}.")
 
-    @jsk_voice.command(name="volume")
+    @jsk_voice.command(name="volume", hidden=JISHAKU_HIDE)
     @commands.check(playing_check)
     async def jsk_vc_volume(self, ctx: commands.Context, *, percentage: float):
         """
@@ -579,7 +579,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
 
         await ctx.send(f"Volume set to {volume * 100:.2f}%")
 
-    @jsk_voice.command(name="play", aliases=["play_local"])
+    @jsk_voice.command(name="play", aliases=["play_local"], hidden=JISHAKU_HIDE)
     @commands.check(connected_check)
     async def jsk_vc_play(self, ctx: commands.Context, *, uri: str):
         """
@@ -599,7 +599,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
         voice.play(discord.PCMVolumeTransformer(discord.FFmpegPCMAudio(uri)))
         await ctx.send(f"Playing in {voice.channel.name}.")
 
-    @jsk_voice.command(name="youtube_dl", aliases=["youtubedl", "ytdl", "yt"])
+    @jsk_voice.command(name="youtube_dl", aliases=["youtubedl", "ytdl", "yt"], hidden=JISHAKU_HIDE)
     @commands.check(connected_check)
     async def jsk_vc_youtube_dl(self, ctx: commands.Context, *, url: str):
         """
@@ -620,7 +620,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
         voice.play(discord.PCMVolumeTransformer(BasicYouTubeDLSource(url)))
         await ctx.send(f"Playing in {voice.channel.name}.")
 
-    @jsk.command(name="su")
+    @jsk.command(name="su", hidden=JISHAKU_HIDE)
     async def jsk_su(self, ctx: commands.Context, target: discord.User, *, command_string: str):
         """
         Run a command as someone else.
@@ -641,7 +641,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
 
         return await alt_ctx.command.invoke(alt_ctx)
 
-    @jsk.command(name="in")
+    @jsk.command(name="in", hidden=JISHAKU_HIDE)
     async def jsk_in(self, ctx: commands.Context, channel: discord.TextChannel, *, command_string: str):
         """
         Run a command as if it were in a different channel.
@@ -654,7 +654,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
 
         return await alt_ctx.command.invoke(alt_ctx)
 
-    @jsk.command(name="sudo")
+    @jsk.command(name="sudo", hidden=JISHAKU_HIDE)
     async def jsk_sudo(self, ctx: commands.Context, *, command_string: str):
         """
         Run a command bypassing all checks and cooldowns.
@@ -669,7 +669,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
 
         return await alt_ctx.command.reinvoke(alt_ctx)
 
-    @jsk.command(name="debug", aliases=["dbg"])
+    @jsk.command(name="debug", aliases=["dbg"], hidden=JISHAKU_HIDE)
     async def jsk_debug(self, ctx: commands.Context, *, command_string: str):
         """
         Run a command timing execution and catching exceptions.
@@ -689,7 +689,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
         end = time.perf_counter()
         return await ctx.send(f"Command `{alt_ctx.command.qualified_name}` finished in {end - start:.3f}s.")
 
-    @jsk.command(name="source", aliases=["src"])
+    @jsk.command(name="source", aliases=["src"], hidden=JISHAKU_HIDE)
     async def jsk_source(self, ctx: commands.Context, *, command_name: str):
         """
         Displays the source code for a command.
@@ -714,7 +714,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
         interface = PaginatorInterface(ctx.bot, paginator, owner=ctx.author)
         await interface.send_to(ctx)
 
-    @jsk.command(name="shutdown", aliases=["logout"])
+    @jsk.command(name="shutdown", aliases=["logout"], hidden=JISHAKU_HIDE)
     async def jsk_shutdown(self, ctx: commands.Context):
         """
         Logs this bot out.


### PR DESCRIPTION
The `hidden` attribute of a group command doesn't affect its subcommands.

Currently, after `jishaku hide`, `jsk` is hidden but the other commands still have their `hidden` attribute set to `False`. It has to directly depends from the environment variable