### PR TITLE
Update reload command to use Bot.reload_extension()

### DIFF
--- a/jishaku/cog.py
+++ b/jishaku/cog.py
@@ -250,12 +250,11 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
             load_icon = "\N{CLOCKWISE RIGHTWARDS AND LEFTWARDS OPEN CIRCLE ARROWS}" \
                         if extension in self.bot.extensions else "\N{INBOX TRAY}"
             try:
-                self.bot.unload_extension(extension)
-                self.bot.load_extension(extension)
+                self.bot.reload_extension(extension)
             except Exception as exc:  # pylint: disable=broad-except
                 traceback_data = ''.join(traceback.format_exception(type(exc), exc, exc.__traceback__, 1))
 
-                paginator.add_line(f"\N{WARNING SIGN} `{extension}`\n```py\n{traceback_data}\n```", empty=True)
+                paginator.add_line(f"\N{WARNING SIGN} `{extension}` - Old extension still loaded\n```py\n{traceback_data}\n```", empty=True)
 
                 if extension in ('jishaku', 'jishaku.cog'):
                     # uh oh

--- a/jishaku/cog.py
+++ b/jishaku/cog.py
@@ -239,7 +239,8 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
         """
         Loads or reloads the given extension names.
 
-        Reports any extensions that failed to load.
+        Reports any extensions that failed to load, but
+        keeps the old extension load
         """
 
         paginator = commands.Paginator(prefix='', suffix='')
@@ -250,11 +251,18 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
             load_icon = "\N{CLOCKWISE RIGHTWARDS AND LEFTWARDS OPEN CIRCLE ARROWS}" \
                         if extension in self.bot.extensions else "\N{INBOX TRAY}"
             try:
-                self.bot.reload_extension(extension)
+                if extension in self.bot.extensions:
+                    load = False
+                    self.bot.reload_extension(extension)
+                else:
+                    load = True
+                    self.bot.load_extension(extension)
             except Exception as exc:  # pylint: disable=broad-except
                 traceback_data = ''.join(traceback.format_exception(type(exc), exc, exc.__traceback__, 1))
-
-                paginator.add_line(f"\N{WARNING SIGN} `{extension}` - Old extension still loaded\n```py\n{traceback_data}\n```", empty=True)
+                if load:
+                    paginator.add_line(f"\N{WARNING SIGN} `{extension}`\n```py\n{traceback_data}\n```", empty=True)
+                else:
+                    paginator.add_line(f"\N{WARNING SIGN} `{extension}` - Old extension still loaded\n```py\n{traceback_data}\n```", empty=True)
 
                 if extension in ('jishaku', 'jishaku.cog'):
                     # uh oh

--- a/jishaku/cog.py
+++ b/jishaku/cog.py
@@ -240,7 +240,8 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
         Loads or reloads the given extension names.
 
         Reports any extensions that failed to load, but
-        keeps the old extension load
+        keeps the old extension loaded if the extension
+        was previously loaded.
         """
 
         paginator = commands.Paginator(prefix='', suffix='')

--- a/requirements/pypi.txt
+++ b/requirements/pypi.txt
@@ -1,3 +1,3 @@
-discord.py>=1.0.0a1761
+discord.py>=1.0.0a1771
 humanize
 import_expression<1.0.0,>=0.3.7


### PR DESCRIPTION
The new version of discord.py adds a new way to reload extensions that keeps the old extension loaded if loading the new extension fails. This is beneficial because users don't lose their commands from that extension if it fails to load.
I also added a message on error telling the user that the old extension is still loaded, as this is a feature of the new Bot.reload_extension. I do not know if this is necessary and/or wanted, so if you want it to be removed I can do that.
Finally, I updated the discord.py requirement to >=1771 because this is the version that has the new Bot.reload_extension().