### PR TITLE
jsk su: try discord.Member first

### DIFF
--- a/jishaku/cog.py
+++ b/jishaku/cog.py
@@ -308,7 +308,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
 
     # Command-invocation commands
     @jsk.command(name="su")
-    async def jsk_su(self, ctx: commands.Context, target: discord.User, *, command_string: str):
+    async def jsk_su(self, ctx: commands.Context, target: typing.Union[discord.Member, discord.User], *, command_string: str):
         """
         Run a command as someone else.
 


### PR DESCRIPTION
Commands that expect ctx.author to be a Member (for example, a command in a guild-only cog, or a command with a guild-only check)
will fail if ctx.author is a User instead. Try converting the specified user to a Member first to resolve this.