### PR TITLE
make ReplAsyncExecutor send sent messages back to the repl generator

### DIFF
--- a/jishaku/repl/compilation.py
+++ b/jishaku/repl/compilation.py
@@ -17,6 +17,7 @@ import inspect
 import sys
 import textwrap
 
+from async_generator import async_generator, yield_, yield_from_
 import import_expression
 
 from .scope import Scope
@@ -147,18 +148,17 @@ class AsyncCodeExecutor:  # pylint: disable=too-few-public-methods
 
         return self.traverse(func_def)
 
+    @async_generator
     async def traverse(self, func):
         """
         Traverses an async function or generator, yielding each result.
 
-        This function is private. The class should be used as an iterator instead of using this method.
+        This function is private. The class should be used as a generator instead of using this method.
         """
-
         # this allows the reference to be stolen
         async_executor = self
 
         if inspect.isasyncgenfunction(func):
-            async for result in func(*async_executor.args):
-                yield result
+            await yield_from_(func(*async_executor.args))
         else:
-            yield await func(*async_executor.args)
+            await yield_(await func(*async_executor.args))

--- a/jishaku/repl/compilation.py
+++ b/jishaku/repl/compilation.py
@@ -17,8 +17,8 @@ import inspect
 import sys
 import textwrap
 
-from async_generator import async_generator, yield_, yield_from_
 import import_expression
+from async_generator import async_generator, yield_, yield_from_
 
 from .scope import Scope
 

--- a/requirements/_.txt
+++ b/requirements/_.txt
@@ -1,3 +1,4 @@
+async_generator
 discord.py>=1.0.0
 humanize
 import_expression<1.0.0,>=0.3.7


### PR DESCRIPTION
Allows snippets such as:

```
m = yield '*smash* that mf like button'
await m.add_reaction('👍')
```

With this, a message would be sent, and a reaction added to that same message.
This required the addition of a dependency: async_generator. This library has a function called
yield_from_ which allows delegating to another async generator without a nasty while True loop, akin
to what `yield from` does in regular, synchronous generators. Generators created with this library are 100%
compatible with regular generators.

Doing so also made the `async for` loop in the jishaku_py command uglier: it was made into a `while True` loop
with two `except StopAsyncIteration: break` occurrences inside it. While this is uglier, this is the standard way
to commmunicate two-ways with an async generator, and is not that much of a hardship considering how little
ReplAsyncExecutor.traverse had to change.