### PR TITLE
modules.resolve_extensions: allow bare * for all modules

### DIFF
--- a/jishaku/modules.py
+++ b/jishaku/modules.py
@@ -66,7 +66,7 @@ def resolve_extensions(bot: commands.Bot, name: str) -> list:
 
         return find_extensions_in(path)
 
-    if name == '~':
+    if name in '~*':
         return list(bot.extensions.keys())
 
     return [name]


### PR DESCRIPTION
This is for consistency with mod.*. Sometimes I forget if it's * or ~.