### PR TITLE
codeblock_converter: support single backticks

### DIFF
--- a/jishaku/cog.py
+++ b/jishaku/cog.py
@@ -31,7 +31,7 @@ import discord
 import humanize
 from discord.ext import commands
 
-from jishaku.codeblocks import Codeblock, CodeblockConverter
+from jishaku.codeblocks import Codeblock, codeblock_converter
 from jishaku.exception_handling import ReplResponseReactor
 from jishaku.functools import AsyncSender
 from jishaku.meta import __version__
@@ -533,7 +533,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
         return await ctx.send("Variable retention is OFF. Future REPL sessions will dispose their scope when done.")
 
     @jsk.command(name="py", aliases=["python"])
-    async def jsk_python(self, ctx: commands.Context, *, argument: CodeblockConverter):
+    async def jsk_python(self, ctx: commands.Context, *, argument: codeblock_converter):
         """
         Direct evaluation of Python code.
         """
@@ -582,7 +582,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
             scope.clear_intersection(arg_dict)
 
     @jsk.command(name="py_inspect", aliases=["pyi", "python_inspect", "pythoninspect"])
-    async def jsk_python_inspect(self, ctx: commands.Context, *, argument: CodeblockConverter):
+    async def jsk_python_inspect(self, ctx: commands.Context, *, argument: codeblock_converter):
         """
         Evaluation of Python code with inspect information.
         """
@@ -616,7 +616,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
 
     # Shell-related commands
     @jsk.command(name="shell", aliases=["sh"])
-    async def jsk_shell(self, ctx: commands.Context, *, argument: CodeblockConverter):
+    async def jsk_shell(self, ctx: commands.Context, *, argument: codeblock_converter):
         """
         Executes statements in the system shell.
 
@@ -641,7 +641,7 @@ class Jishaku(commands.Cog):  # pylint: disable=too-many-public-methods
                 await interface.add_line(f"\n[status] Return code {reader.close_code}")
 
     @jsk.command(name="git")
-    async def jsk_git(self, ctx: commands.Context, *, argument: CodeblockConverter):
+    async def jsk_git(self, ctx: commands.Context, *, argument: codeblock_converter):
         """
         Shortcut for 'jsk sh git'. Invokes the system shell.
         """

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -9,24 +9,19 @@ jishaku converter test
 
 """
 
-import asyncio
 import inspect
 
-from jishaku.codeblocks import Codeblock, CodeblockConverter
+from jishaku.codeblocks import Codeblock, codeblock_converter
 
 
 def test_codeblock_converter():
-    loop = asyncio.get_event_loop()
-
-    conv = CodeblockConverter()
-
     text = """
     ```py
     one
     ```
     """
 
-    codeblock = loop.run_until_complete(conv.convert(None, inspect.cleandoc(text)))
+    codeblock = codeblock_converter(inspect.cleandoc(text))
 
     assert isinstance(codeblock, Codeblock)
     assert codeblock.content.strip() == 'one'
@@ -38,7 +33,7 @@ def test_codeblock_converter():
     ```
     """
 
-    codeblock = loop.run_until_complete(conv.convert(None, inspect.cleandoc(text)))
+    codeblock = codeblock_converter(inspect.cleandoc(text))
 
     assert isinstance(codeblock, Codeblock)
     assert codeblock.content.strip() == 'two'
@@ -50,7 +45,7 @@ def test_codeblock_converter():
     ```
     """
 
-    codeblock = loop.run_until_complete(conv.convert(None, inspect.cleandoc(text)))
+    codeblock = codeblock_converter(inspect.cleandoc(text))
 
     assert isinstance(codeblock, Codeblock)
     assert codeblock.content.strip() == 'three'
@@ -62,20 +57,18 @@ def test_codeblock_converter():
     ```
     """
 
-    codeblock = loop.run_until_complete(conv.convert(None, inspect.cleandoc(text)))
+    codeblock = codeblock_converter(inspect.cleandoc(text))
 
     assert isinstance(codeblock, Codeblock)
     assert codeblock.content.strip() == 'four'
-    assert codeblock.language == ''
     assert not codeblock.language
 
     text = "five"
 
-    codeblock = loop.run_until_complete(conv.convert(None, inspect.cleandoc(text)))
+    codeblock = codeblock_converter(inspect.cleandoc(text))
 
     assert isinstance(codeblock, Codeblock)
     assert codeblock.content.strip() == 'five'
-    assert codeblock.language is None
     assert not codeblock.language
 
     text = """
@@ -83,18 +76,39 @@ def test_codeblock_converter():
     ```
     """
 
-    codeblock = loop.run_until_complete(conv.convert(None, inspect.cleandoc(text)))
+    codeblock = codeblock_converter(inspect.cleandoc(text))
 
     assert isinstance(codeblock, Codeblock)
-    assert codeblock.content.strip() == 'six'
-    assert codeblock.language is None
+    assert codeblock.content.strip() == 'six\n```'
     assert not codeblock.language
 
     text = ""
 
-    codeblock = loop.run_until_complete(conv.convert(None, inspect.cleandoc(text)))
+    codeblock = codeblock_converter(inspect.cleandoc(text))
 
     assert isinstance(codeblock, Codeblock)
     assert codeblock.content.strip() == ''
-    assert codeblock.language is None
+    assert not codeblock.language
+
+    text = """
+    ```
+    se``ven
+    ```
+    """
+
+    codeblock = codeblock_converter(inspect.cleandoc(text))
+    assert isinstance(codeblock, Codeblock)
+    assert codeblock.content.strip() == 'se``ven'
+    assert not codeblock.language
+
+    text = "``ei`ght``"
+    codeblock = codeblock_converter(text)
+    assert isinstance(codeblock, Codeblock)
+    assert codeblock.content.strip() == 'ei`ght'
+    assert not codeblock.language
+
+    text = "`nine`"
+    codeblock = codeblock_converter(text)
+    assert isinstance(codeblock, Codeblock)
+    assert codeblock.content.strip() == 'nine'
     assert not codeblock.language


### PR DESCRIPTION
- Replaces the code block regex with a home-grown, organic, non-GMO, grass-fed parser that supports \`foo\`, \`\`fo\`o\`\`, and \`\`foo\`\`.
- Update the tests to match the new behavior of '\nfoo\n\`\`\`'
(previously stripped trailing \`\`\`, now doesn't in order to be consistent with Discord's behavior)