### PR TITLE
extension management commands: support bash-style brace syntax

### DIFF
--- a/docs/cog.rst
+++ b/docs/cog.rst
@@ -195,6 +195,9 @@ Commands
     Extensions can be specified en masse by typing e.g. ``cogs.*``.
     This searches for anything that looks like an extension in the folder and loads/reloads it.
 
+    Brace expansion works as well, such as ``foo.bar.cogs.{baz,quux,garply}`` to reload ``foo.bar.cogs.baz``,
+    ``foo.bar.cogs.quux``, and ``foo.bar.cogs.garply``.
+
     ``jsk reload ~`` will reload every extension the bot currently has loaded.
 
 

--- a/requirements/_.txt
+++ b/requirements/_.txt
@@ -1,3 +1,4 @@
+braceexpand>=0.1.2
 discord.py>=1.3.0a2084
 humanize
 import_expression<1.0.0,>=0.3.7


### PR DESCRIPTION
### Rationale

It's a lot of typing to reload many extensions in my bot, both because they all start with `emote_collector.extensions.` and because they are fairly nested. It gets even worse with more nesting and repetition, like `cautious_memory.cogs.{wiki,permissions}.{commands,db}`.

### Summary of changes made

1. Pulls in braceexpand as a dependency
1. Rewrites jishaku.modules.find_extensions_in to support brace expansion
1. Handles the resulting UnbalancedBracesError in ExtensionConverter

### Checklist

- [x] This PR changes the jishaku module/cog codebase
    - [x] These changes add new functionality to the module/cog
    - [ ] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot instance
    - [x] I have tested these changes against the CI/CD test suite
    - [x] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [x] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [x] I have proofread my changes for grammar and spelling issues
    - [x] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
