### PR TITLE
requirements: bump import_expression version

### DIFF
--- a/requirements/_.txt
+++ b/requirements/_.txt
@@ -1,4 +1,4 @@
 braceexpand>=0.1.2
 discord.py>=1.2.3
 humanize
-import_expression<1.0.0,>=0.3.7
+import_expression<1.0.0,>=0.6.0


### PR DESCRIPTION
Relevant changes since 0.3.7:
- `import x!` errors
- `a!.b!` errors
- `a.!.b` errors
- `!` (on its own) errors
- syntax errors raised by import_expression now include the text of the source code that caused the error

### Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [ ] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [ ] These changes fix an issue or bug in the module/cog
    - [ ] I have tested that these changes work on a production bot instance
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
