### PR TITLE
Use prefix_len in WrappedPaginator

### DIFF
--- a/jishaku/paginators.py
+++ b/jishaku/paginators.py
@@ -342,7 +342,7 @@ class WrappedPaginator(commands.Paginator):
         self.include_wrapped = include_wrapped
 
     def add_line(self, line='', *, empty=False):
-        true_max_size = self.max_size - len(self.prefix) - 2
+        true_max_size = self.max_size - self._prefix_len - self._suffix_len - 2
 
         while len(line) > true_max_size:
             search_string = line[0:true_max_size - 1]

--- a/jishaku/paginators.py
+++ b/jishaku/paginators.py
@@ -342,7 +342,7 @@ class WrappedPaginator(commands.Paginator):
         self.include_wrapped = include_wrapped
 
     def add_line(self, line='', *, empty=False):
-        true_max_size = self.max_size - self._prefix_len - self._suffix_len - 2
+        true_max_size = self.max_size - self._prefix_len - 2
 
         while len(line) > true_max_size:
             search_string = line[0:true_max_size - 1]


### PR DESCRIPTION
### Rationale

<!-- What is the reason behind this change? How does implementing it benefit end users or contributors? -->

This allows prefix and suffix to be set to None as with normal commands.Paginator

### Summary of changes made

<!-- An explanation, in plain English, of your implementation of this change. -->

I changed WrappedPaginator's add_line to use commands.Paginator's 
_prefix_len to get max page size.

### Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot instance
    - [x] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
