### PR TITLE
Update cog.py

### DIFF
--- a/jishaku/cog.py
+++ b/jishaku/cog.py
@@ -59,21 +59,24 @@ async def jsk(self, ctx: commands.Context):
     ]
 
     if psutil:
-        proc = psutil.Process()
+        try:
+            proc = psutil.Process()
 
-        with proc.oneshot():
-            mem = proc.memory_full_info()
-            summary.append(f"Using {humanize.naturalsize(mem.rss)} physical memory and "
-                           f"{humanize.naturalsize(mem.vms)} virtual memory, "
-                           f"{humanize.naturalsize(mem.uss)} of which unique to this process.")
+            with proc.oneshot():
+                mem = proc.memory_full_info()
+                summary.append(f"Using {humanize.naturalsize(mem.rss)} physical memory and "
+                               f"{humanize.naturalsize(mem.vms)} virtual memory, "
+                               f"{humanize.naturalsize(mem.uss)} of which unique to this process.")
 
-            name = proc.name()
-            pid = proc.pid
-            thread_count = proc.num_threads()
+                name = proc.name()
+                pid = proc.pid
+                thread_count = proc.num_threads()
 
-            summary.append(f"Running on PID {pid} (`{name}`) with {thread_count} thread(s).")
+                summary.append(f"Running on PID {pid} (`{name}`) with {thread_count} thread(s).")
 
-            summary.append("")  # blank line
+                summary.append("")  # blank line
+        except psutil.AccessDenied as e:
+            pass
 
     cache_summary = f"{len(self.bot.guilds)} guild(s) and {len(self.bot.users)} user(s)"
 


### PR DESCRIPTION
Prevents psutil.AccessDenied

### Rationale

<!-- What is the reason behind this change? How does implementing it benefit end users or contributors? -->

Sometimes when users doesn't have enough permissions to use some psutil things, they got AccessDenied error thrown and impacts the $jsk command not being able to run correctly

### Summary of changes made

Pretend psutil didn't exist when AccessDenied Exception got thrown
<!-- An explanation, in plain English, of your implementation of this change. -->

### Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot instance
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
