### PR TITLE
Logout command prints "Logging out now.."

### DIFF
--- a/jishaku/cog_base.py
+++ b/jishaku/cog_base.py
@@ -243,7 +243,7 @@ class JishakuBase(commands.Cog):  # pylint: disable=too-many-public-methods
         Logs this bot out.
         """
 
-        await ctx.send("Logging out now..")
+        await ctx.send("Logging out now.")
         await ctx.bot.logout()
 
     # Command-invocation commands


### PR DESCRIPTION
### Rationale
When you execute the `jishaku logout` command, the bot sends the message `Logging out now..`. There should either be one or three periods here, not two.
<!-- What is the reason behind this change? How does implementing it benefit end users or contributors? -->

### Summary of changes made
I have removed one of the periods so that the message reads `Logging out now.`, but if you intended there to be three periods here, do let me know.
<!-- An explanation, in plain English, of your implementation of this change. -->

### Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot instance
    - [x] I have tested these changes against the CI/CD test suite
    - [N/A] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
