### PR TITLE
Update REPL to no longer use a removed asyncio classmethod

### DIFF
--- a/jishaku/cog_base.py
+++ b/jishaku/cog_base.py
@@ -90,7 +90,7 @@ class JishakuBase(commands.Cog):  # pylint: disable=too-many-public-methods
         """
 
         self.task_count += 1
-        cmdtask = CommandTask(self.task_count, ctx, asyncio.Task.current_task())
+        cmdtask = CommandTask(self.task_count, ctx, asyncio.current_task())
         self.tasks.append(cmdtask)
 
         try:

--- a/jishaku/meta.py
+++ b/jishaku/meta.py
@@ -25,7 +25,7 @@ __all__ = (
 
 # pylint: disable=invalid-name
 VersionInfo = namedtuple('VersionInfo', 'major minor micro releaselevel serial')
-version_info = VersionInfo(major=1, minor=19, micro=0, releaselevel='final', serial=0)
+version_info = VersionInfo(major=1, minor=20, micro=0, releaselevel='final', serial=0)
 
 __author__ = 'Gorialis'
 __copyright__ = 'Copyright 2020 Devon (Gorialis) R'


### PR DESCRIPTION
### Rationale

<!-- What is the reason behind this change? How does implementing it benefit end users or contributors? -->
Python 3.9 removes the deprecated `asyncio.Task.current_task()` and moves it to `asyncio.current_task()`. This affected the Python REPL, which makes it impossible to use the `jsk py` command in Python 3.9 onward. This PR uses the new way of getting the current asyncio task.

This change will no longer support Python version 3.6 or lower.

### Summary of changes made

<!-- An explanation, in plain English, of your implementation of this change. -->
- Changes `asyncio.Task.current_task()` to `asyncio.current_task()` in jishaku/cog_base.py at line 93
- Changes the minor version number from 19 to 20 in jishaku/meta.py at line 28

### Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot instance
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
