### PR TITLE
Bring back Braille J

### DIFF
--- a/jishaku/cog_base.py
+++ b/jishaku/cog_base.py
@@ -262,7 +262,7 @@ class JishakuBase(commands.Cog):  # pylint: disable=too-many-public-methods
         Logs this bot out.
         """
 
-        await ctx.send("Logging out now...")
+        await ctx.send("Logging out now\N{BRAILLE PATTERN DOTS-356}")
         await ctx.bot.logout()
 
     # Command-invocation commands


### PR DESCRIPTION
## Rationale

It seems to look better if the `BRAILLE PATTERN DOTS-356` character (`⠴`) is used, over three periods `...`.

## Summary of changes made

Brought back the inexplicably removed legendary Braille J.

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [ ] I have tested that these changes work on a production bot instance
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
