### PR TITLE
Fix regression in logout command

### DIFF
--- a/jishaku/cog_base.py
+++ b/jishaku/cog_base.py
@@ -262,7 +262,7 @@ class JishakuBase(commands.Cog):  # pylint: disable=too-many-public-methods
         Logs this bot out.
         """
 
-        await ctx.send("Logging out now...")
+        await ctx.send("Logging out now\N{BRAILLE PATTERN DOTS-356}")
         await ctx.bot.logout()
 
     # Command-invocation commands


### PR DESCRIPTION
### Rationale

The format of the logout command changed suddenly with no explanation or mention of its change in commit messages or changelogs. It should be reverted and discussion required before changing such a vital part of the user interface.

### Summary of changes made

The ellipsis (...) in the response message of jsk logout was replaced with a braille J (⠴).

### Checklist

- [x] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot instance
    - [x] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
