### PR TITLE
PR template: use <h2> instead of <h3>

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,12 @@
-### Rationale
+## Rationale
 
 <!-- What is the reason behind this change? How does implementing it benefit end users or contributors? -->
 
-### Summary of changes made
+## Summary of changes made
 
 <!-- An explanation, in plain English, of your implementation of this change. -->
 
-### Checklist
+## Checklist
 
 <!-- To check a box, place an x in the box (with no spaces), like so: [x] -->
 


### PR DESCRIPTION
## Rationale

\<h2\> is the semantically correct heading here,
as \<h1\> is for document titles and \<h2\> is for the top level headings within a document.
\<h3\> should be used for subheadings of \<h2\> headings.

## Summary of changes made

I changed the headings from h3 to h2 in the PR template.

## Checklist

- [ ] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [ ] These changes fix an issue or bug in the module/cog
    - [ ] I have tested that these changes work on a production bot instance
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [x] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [x] I have proofread my changes for grammar and spelling issues
    - [x] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
