### PR TITLE
jsk su: use fetch_member

### DIFF
--- a/jishaku/cog_base.py
+++ b/jishaku/cog_base.py
@@ -274,13 +274,17 @@ class JishakuBase(commands.Cog):  # pylint: disable=too-many-public-methods
         This will try to resolve to a Member, but will use a User if it can't find one.
         """
 
+        author = target
         if ctx.guild:
             # Try to upgrade to a Member instance
             # This used to be done by a Union converter, but doing it like this makes
             #  the command more compatible with chaining, e.g. `jsk in .. jsk su ..`
-            target = ctx.guild.get_member(target.id) or target
+            author = ctx.guild.get_member(target.id)
+            if author is None:
+                with contextlib.suppress(discord.HTTPException):
+                    author = await ctx.guild.fetch_member(target.id)
 
-        alt_ctx = await copy_context_with(ctx, author=target, content=ctx.prefix + command_string)
+        alt_ctx = await copy_context_with(ctx, author=author, content=ctx.prefix + command_string)
 
         if alt_ctx.command is None:
             if alt_ctx.invoked_with is None:


### PR DESCRIPTION
## Rationale

some of us in the intents gang have no member cache 😔😔 so we have to resort to HTTP calls

## Summary of changes made

I made `jsk su` try to upgrade the passed User object to a Member using `Guild.fetch_member` in addition to `Guild.get_member` because some of us be out here with　ｓｔａｔｅｌｅｓｓ　bots that have no member cache.

## Checklist

- [x] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot instance
    - [x] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
