### PR TITLE
use <h2> for the rest of the templates as well

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -3,23 +3,23 @@ name: Bug Report
 about: Report broken or incorrect behavior or functionality
 ---
 
-### Summary
+## Summary
 
 <!-- A summary of your bug report -->
 
-### Reproduction steps
+## Reproduction steps
 
 <!-- Under what conditions does this bug occur? Is there a consistent method to reproduce the bug, and if so - what is it? If code is used in the reproduction process, please produce it here. -->
 
-### Expected results
+## Expected results
 
 <!-- What you expected to occur as a result of your reproduction steps -->
 
-### Actual results
+## Actual results
 
 <!-- What actually occurred as a result of your reproduction steps - i.e., the broken/incorrect behavior. -->
 
-### Checklist
+## Checklist
 
 <!-- To check a box, place an x in the box (with no spaces), like so: [x] -->
 
@@ -28,7 +28,7 @@ about: Report broken or incorrect behavior or functionality
 - [ ] I have shown the entire traceback, if possible
 - [ ] I have removed my token from display, if visible
 
-### System information
+## System information
 
 <!-- Post information both about your jishaku AND discord.py version here -->
 <!-- You can get information about discord.py by running `python -m discord -v` -->

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -3,24 +3,24 @@ name: Feature Request
 about: Suggest a feature for this library
 ---
 
-### The Problem
+## The Problem
 
 <!--
 What problem is your feature trying to solve? What becomes easier or possible when this feature is implemented?
 -->
 
-### The Ideal Solution
+## The Ideal Solution
 
 <!--
 What is your ideal solution to the problem? What would you like this feature to do?
 -->
 
-### The Current Solution
+## The Current Solution
 
 <!--
 What is the current solution to the problem, if any?
 -->
 
-### Summary
+## Summary
 
 <!-- A short summary of your feature request. -->


### PR DESCRIPTION
## Rationale

I missed some in #70. Sorry for the trivial PR.

## Summary of changes made

I changed more `###` headers to `##` ones.

## Checklist

- [ ] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [ ] These changes fix an issue or bug in the module/cog
    - [ ] I have tested that these changes work on a production bot instance
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [x] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [x] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
