### PR TITLE
Added raw_reaction_remove in paginator.

### DIFF
--- a/jishaku/paginators.py
+++ b/jishaku/paginators.py
@@ -264,7 +264,7 @@ class PaginatorInterface:  # pylint: disable=too-many-instance-attributes
             return all(tests)
 
         try:
-             while not self.bot.is_closed():
+            while not self.bot.is_closed():
                 tasks = [
                     asyncio.ensure_future(self.bot.wait_for('raw_reaction_add', check=check)),
                     asyncio.ensure_future(self.bot.wait_for('raw_reaction_remove', check=check))

--- a/jishaku/paginators.py
+++ b/jishaku/paginators.py
@@ -264,6 +264,7 @@ class PaginatorInterface:  # pylint: disable=too-many-instance-attributes
             return all(tests)
 
         try:
+           # pylint: disable=Too many branches
             while not self.bot.is_closed():
                 tasks = [
                     asyncio.ensure_future(self.bot.wait_for('raw_reaction_add', check=check)),

--- a/jishaku/paginators.py
+++ b/jishaku/paginators.py
@@ -264,8 +264,8 @@ class PaginatorInterface:  # pylint: disable=too-many-instance-attributes
             return all(tests)
 
         try:
-           # pylint: disable=Too many branches
             while not self.bot.is_closed():
+                # pylint: disable=R0912
                 tasks = [
                     asyncio.ensure_future(self.bot.wait_for('raw_reaction_add', check=check)),
                     asyncio.ensure_future(self.bot.wait_for('raw_reaction_remove', check=check))

--- a/jishaku/paginators.py
+++ b/jishaku/paginators.py
@@ -294,12 +294,7 @@ class PaginatorInterface:  # pylint: disable=too-many-instance-attributes
                     self._display_page += 1
 
                 self.bot.loop.create_task(self.update())
-
-                try:
-                    await self.message.remove_reaction(payload.emoji, discord.Object(id=payload.user_id))
-                except discord.Forbidden:
-                    pass
-
+                      
         except (asyncio.CancelledError, asyncio.TimeoutError):
             if self.delete_message:
                 return await self.message.delete()

--- a/jishaku/paginators.py
+++ b/jishaku/paginators.py
@@ -264,7 +264,7 @@ class PaginatorInterface:  # pylint: disable=too-many-instance-attributes
             return all(tests)
 
         try:
-              while not self.bot.is_closed():
+             while not self.bot.is_closed():
                 tasks = [
                     asyncio.ensure_future(self.bot.wait_for('raw_reaction_add', check=check)),
                     asyncio.ensure_future(self.bot.wait_for('raw_reaction_remove', check=check))

--- a/jishaku/paginators.py
+++ b/jishaku/paginators.py
@@ -235,7 +235,7 @@ class PaginatorInterface:  # pylint: disable=too-many-instance-attributes
             return False
         return self.task.done()
 
-    async def wait_loop(self): # pylint: disable=R0912
+    async def wait_loop(self):  # pylint: disable=R0912
         """
         Waits on a loop for reactions to the message. This should not be called manually - it is handled by `send_to`.
         """

--- a/jishaku/paginators.py
+++ b/jishaku/paginators.py
@@ -235,7 +235,7 @@ class PaginatorInterface:  # pylint: disable=too-many-instance-attributes
             return False
         return self.task.done()
 
-    async def wait_loop(self):
+    async def wait_loop(self): # pylint: disable=R0912
         """
         Waits on a loop for reactions to the message. This should not be called manually - it is handled by `send_to`.
         """
@@ -265,7 +265,6 @@ class PaginatorInterface:  # pylint: disable=too-many-instance-attributes
 
         try:
             while not self.bot.is_closed():
-                # pylint: disable=R0912
                 tasks = [
                     asyncio.ensure_future(self.bot.wait_for('raw_reaction_add', check=check)),
                     asyncio.ensure_future(self.bot.wait_for('raw_reaction_remove', check=check))

--- a/jishaku/paginators.py
+++ b/jishaku/paginators.py
@@ -264,6 +264,7 @@ class PaginatorInterface:  # pylint: disable=too-many-instance-attributes
             return all(tests)
 
         try:
+              while not self.bot.is_closed():
                 tasks = [
                     asyncio.ensure_future(self.bot.wait_for('raw_reaction_add', check=check)),
                     asyncio.ensure_future(self.bot.wait_for('raw_reaction_remove', check=check))


### PR DESCRIPTION
Added reaction_remove in paginator so you don't have to click twice to go the next page.

## Rationale

<!-- What is the reason behind this change? How does implementing it benefit end users or contributors? -->
The reason behind this change is because I find it is annoying to click twice to go to the next page I believe it will benefit to users because I do believe most people don't like to click twice to go to the next page.
## Summary of changes made
I used asyncio.ensure_future and asyncio.wait to wait for either event to be fired.
<!-- An explanation, in plain English, of your implementation of this change. -->

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [x] These changes add new functionality to the module/cog
    - [ ] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
