### PR TITLE
Add option to cancel every running task

### DIFF
--- a/jishaku/features/root_command.py
+++ b/jishaku/features/root_command.py
@@ -22,6 +22,7 @@ from jishaku.flags import JISHAKU_HIDE
 from jishaku.meta import __version__
 from jishaku.modules import package_version
 from jishaku.paginators import PaginatorInterface
+import typing
 
 try:
     import psutil
@@ -161,7 +162,7 @@ class RootCommand(Feature):
         return await interface.send_to(ctx)
 
     @Feature.Command(parent="jsk", name="cancel")
-    async def jsk_cancel(self, ctx: commands.Context, *, index: int):
+    async def jsk_cancel(self, ctx: commands.Context, *, index: typing.Union[int, str]):
         """
         Cancels a task with the given index.
 
@@ -173,6 +174,11 @@ class RootCommand(Feature):
 
         if index == -1:
             task = self.tasks.pop()
+        elif index == '~':
+            for task in enumerate(list(self.tasks)):
+                self.tasks.remove(task[1])
+                task[1].task.cancel()
+            return await ctx.send('Cancelled all tasks')
         else:
             task = discord.utils.get(self.tasks, index=index)
             if task:


### PR DESCRIPTION
## Rationale

Make it easier to cancel every task without having to run jsk cancel many times

## Summary of changes made

Add a check for ~, loop through all tasks, and cancel them.

## Checklist

- [x] This PR changes the jishaku module/cog codebase
    - [x] These changes add new functionality to the module/cog
    - [ ] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
