### PR TITLE
Fix PaginatorInterface not closing with timeout

### DIFF
--- a/jishaku/paginators.py
+++ b/jishaku/paginators.py
@@ -291,6 +291,9 @@ class PaginatorInterface:  # pylint: disable=too-many-instance-attributes
             while not self.bot.is_closed():
                 done, _ = await asyncio.wait(task_list, timeout=self.timeout, return_when=asyncio.FIRST_COMPLETED)
 
+                if not done:
+                    raise asyncio.TimeoutError
+
                 for task in done:
                     task_list.remove(task)
                     payload = task.result()


### PR DESCRIPTION
## Rationale

Fixes PaginatorInterface timeout not working (resolves #94).

## Summary of changes made

Added a check to test whether none of the Tasks being waited for are done, and raises `asyncio.TimeoutError` in order to allow the behavior described in https://github.com/Gorialis/jishaku/issues/87#issuecomment-786282766

There's no message attached to the exception as using `asyncio.wait_for` also does not set one and I was unsure what it should be.

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [x] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
