### PR TITLE
Bot.logout was deprecated

### DIFF
--- a/jishaku/features/management.py
+++ b/jishaku/features/management.py
@@ -98,7 +98,7 @@ class ManagementFeature(Feature):
         """
 
         await ctx.send("Logging out now\N{HORIZONTAL ELLIPSIS}")
-        await ctx.bot.logout()
+        await ctx.bot.close()
 
     @Feature.Command(parent="jsk", name="rtt", aliases=["ping"])
     async def jsk_rtt(self, ctx: commands.Context):


### PR DESCRIPTION
## Rationale
After discord.py 1.7 update, Bot.logout was deprecated. This warning keeps popping up.

```py
C:\Users\sarah\AppData\Local\Programs\Python\Python39-32\lib\site-packages\discord\ext\commands\core.py:85: 
 DeprecationWarning: logout is deprecated, use Client.close instead.
    ret = await coro(*args, **kwargs)
```

## Summary of changes made
`jsk_shutdown` was using `bot.logout` so I changed it to `bot.close`

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
