### PR TITLE
Adding support for the mobile/force paginator flag

### DIFF
--- a/jishaku/features/filesystem.py
+++ b/jishaku/features/filesystem.py
@@ -24,6 +24,7 @@ from jishaku.exception_handling import ReplResponseReactor
 from jishaku.features.baseclass import Feature
 from jishaku.hljs import get_language, guess_file_traits
 from jishaku.paginators import PaginatorInterface, WrappedFilePaginator
+from jishaku.flags import JISHAKU_FORCE_PAGINATOR
 
 
 class FilesystemFeature(Feature):
@@ -68,7 +69,7 @@ class FilesystemFeature(Feature):
 
         try:
             with open(path, "rb") as file:
-                if size < 50_000:  # File "full content" preview limit
+                if size < 50_000 and not ctx.author.is_on_mobile() and not JISHAKU_FORCE_PAGINATOR:  # File "full content" preview limit
                     if line_span:
                         content, *_ = guess_file_traits(file.read())
 
@@ -116,7 +117,7 @@ class FilesystemFeature(Feature):
             if not data:
                 return await ctx.send(f"HTTP response was empty (status code {code}).")
 
-            if len(data) < 50_000:  # File "full content" preview limit
+            if len(data) < 50_000 and not ctx.author.is_on_mobile() and not JISHAKU_FORCE_PAGINATOR:  # File "full content" preview limit
                 # Shallow language detection
                 language = None
 

--- a/jishaku/features/invocation.py
+++ b/jishaku/features/invocation.py
@@ -24,6 +24,7 @@ from jishaku.exception_handling import ReplResponseReactor
 from jishaku.features.baseclass import Feature
 from jishaku.models import copy_context_with
 from jishaku.paginators import PaginatorInterface, WrappedPaginator
+from jishaku.flags import JISHAKU_FORCE_PAGINATOR
 
 
 class InvocationFeature(Feature):
@@ -150,7 +151,7 @@ class InvocationFeature(Feature):
         # getsourcelines for some reason returns WITH line endings
         source_text = ''.join(source_lines)
 
-        if len(source_text) < 50_000:  # File "full content" preview limit
+        if len(source_text) < 50_000 and not ctx.author.is_on_mobile() and not JISHAKU_FORCE_PAGINATOR:  # File "full content" preview limit
             await ctx.send(file=discord.File(
                 filename=filename,
                 fp=io.BytesIO(source_text.encode('utf-8'))

--- a/jishaku/features/python.py
+++ b/jishaku/features/python.py
@@ -19,7 +19,7 @@ from discord.ext import commands
 from jishaku.codeblocks import codeblock_converter
 from jishaku.exception_handling import ReplResponseReactor
 from jishaku.features.baseclass import Feature
-from jishaku.flags import JISHAKU_RETAIN, SCOPE_PREFIX
+from jishaku.flags import JISHAKU_RETAIN, SCOPE_PREFIX, JISHAKU_FORCE_PAGINATOR
 from jishaku.functools import AsyncSender
 from jishaku.paginators import PaginatorInterface, WrappedPaginator
 from jishaku.repl import AsyncCodeExecutor, Scope, all_inspections, disassemble, get_var_dict_from_ctx
@@ -115,7 +115,7 @@ class PythonFeature(Feature):
 
                                 send(await ctx.send(result.replace(self.bot.http.token, "[token omitted]")))
 
-                            elif len(result) < 50_000:  # File "full content" preview limit
+                            elif len(result) < 50_000 and not ctx.author.is_on_mobile() and not JISHAKU_FORCE_PAGINATOR:  # File "full content" preview limit
                                 # Discord's desktop and web client now supports an interactive file content
                                 #  display for files encoded in UTF-8.
                                 # Since this avoids escape issues and is more intuitive than pagination for
@@ -169,7 +169,7 @@ class PythonFeature(Feature):
 
                         text = "\n".join(lines)
 
-                        if len(text) < 50_000:  # File "full content" preview limit
+                        if len(text) < 50_000 and not ctx.author.is_on_mobile() and not JISHAKU_FORCE_PAGINATOR:  # File "full content" preview limit
                             send(await ctx.send(file=discord.File(
                                 filename="inspection.prolog",
                                 fp=io.BytesIO(text.encode('utf-8'))
@@ -195,7 +195,7 @@ class PythonFeature(Feature):
         async with ReplResponseReactor(ctx.message):
             text = "\n".join(disassemble(argument.content, arg_dict=arg_dict))
 
-            if len(text) < 50_000:  # File "full content" preview limit
+            if len(text) < 50_000 and not ctx.author.is_on_mobile() and not JISHAKU_FORCE_PAGINATOR:  # File "full content" preview limit
                 await ctx.send(file=discord.File(
                     filename="dis.py",
                     fp=io.BytesIO(text.encode('utf-8'))

--- a/jishaku/flags.py
+++ b/jishaku/flags.py
@@ -34,6 +34,10 @@ JISHAKU_RETAIN = enabled("JISHAKU_RETAIN")
 JISHAKU_NO_UNDERSCORE = enabled("JISHAKU_NO_UNDERSCORE")
 SCOPE_PREFIX = '' if JISHAKU_NO_UNDERSCORE else '_'
 
+# Flag to indicate whether or not to always use paginators in commands that now use files
+# as there is no file preview on mobile and some people just like the paginators better.
+JISHAKU_FORCE_PAGINATOR = enabled("JISHAKU_FORCE_PAGINATOR")
+
 # Flag to indicate verbose error tracebacks should be sent to the invoking channel as opposed to via direct message.
 JISHAKU_NO_DM_TRACEBACK = enabled("JISHAKU_NO_DM_TRACEBACK")
 


### PR DESCRIPTION
## Rationale
<!-- What is the reason behind this change? How does implementing it benefit end users or contributors? -->
Some users dislike the new file output, and would rather have paginators.
It's also not a viable option to have as the _only_ option, as a lot of people use mobile, and there's no file preview option on mobile.
The best way to view these files on mobile is downloading them, finding them in the file system, and figuring out what app to open in.

## Summary of changes made
<!-- An explanation, in plain English, of your implementation of this change. -->
I created a new `.env` flag, titled `JISHAKU_FORCE_PAGINATOR` which would force the output to use paginator regardless of device.
I also added a check for `ctx.author.is_on_mobile()`, in which case it will default to paginators on mobile regardless of the flag setting.
These checks were placed everywhere there is a check for `len(result) < 50_000` (`features/[filesystem|invocation|python].py`, `flags.py`)
I don't believe I missed any, but please add it if I did :)

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
