### PR TITLE
Adding RTFD and changing ReplResponseReactor a bit

### DIFF
--- a/jishaku/cog.py
+++ b/jishaku/cog.py
@@ -19,6 +19,7 @@ from jishaku.features.invocation import InvocationFeature
 from jishaku.features.management import ManagementFeature
 from jishaku.features.python import PythonFeature
 from jishaku.features.root_command import RootCommand
+from jishaku.features.rtfd import RTFD
 from jishaku.features.shell import ShellFeature
 from jishaku.features.voice import VoiceFeature
 
@@ -29,7 +30,7 @@ __all__ = (
     "setup",
 )
 
-STANDARD_FEATURES = (VoiceFeature, GuildFeature, FilesystemFeature, InvocationFeature, ShellFeature, PythonFeature, ManagementFeature, RootCommand)
+STANDARD_FEATURES = (VoiceFeature, GuildFeature, FilesystemFeature, InvocationFeature, ShellFeature, PythonFeature, ManagementFeature, RootCommand, RTFD)
 
 OPTIONAL_FEATURES = []
 

--- a/jishaku/exception_handling.py
+++ b/jishaku/exception_handling.py
@@ -86,10 +86,11 @@ class ReactionProcedureTimer:  # pylint: disable=too-few-public-methods
     """
     Class that reacts to a message based on what happens during its lifetime.
     """
-    __slots__ = ('message', 'loop', 'handle', 'raised')
+    __slots__ = ('ctx', 'message', 'loop', 'handle', 'raised')
 
-    def __init__(self, message: discord.Message, loop: typing.Optional[asyncio.BaseEventLoop] = None):
-        self.message = message
+    def __init__(self, ctx: commands.Context, loop: typing.Optional[asyncio.BaseEventLoop] = None):
+        self.ctx = ctx
+        self.message = ctx.message
         self.loop = loop or asyncio.get_event_loop()
         self.handle = None
         self.raised = False
@@ -135,11 +136,11 @@ class ReplResponseReactor(ReactionProcedureTimer):  # pylint: disable=too-few-pu
 
         if isinstance(exc_val, (SyntaxError, asyncio.TimeoutError, subprocess.TimeoutExpired)):
             # short traceback, send to channel
-            await send_traceback(self.message.channel, 0, exc_type, exc_val, exc_tb)
+            await send_traceback(self.ctx, 0, exc_type, exc_val, exc_tb)
         else:
             # this traceback likely needs more info, so increase verbosity, and DM it instead.
             await send_traceback(
-                self.message.channel if JISHAKU_NO_DM_TRACEBACK else self.message.author,
+                self.ctx if JISHAKU_NO_DM_TRACEBACK else self.message.author,
                 8, exc_type, exc_val, exc_tb
             )
 

--- a/jishaku/features/baseclass.py
+++ b/jishaku/features/baseclass.py
@@ -16,6 +16,7 @@ import collections
 import contextlib
 import datetime
 import typing
+import aiohttp
 
 from discord.ext import commands
 
@@ -61,7 +62,7 @@ class Feature(commands.Cog):
         self.start_time: datetime.datetime = datetime.datetime.now()
         self.tasks = collections.deque()
         self.task_count: int = 0
-
+        self.session = getattr(self, 'session', getattr(self.bot, 'session', aiohttp.ClientSession()))
         # Generate and attach commands
         command_lookup = {}
 
@@ -133,6 +134,10 @@ class Feature(commands.Cog):
         if not await ctx.bot.is_owner(ctx.author):
             raise commands.NotOwner("You must own this bot to use Jishaku.")
         return True
+
+    def cog_unload(self):
+        if getattr(self, 'session') and not getattr(self.bot, 'session'):
+            self.bot.loop.create_task(self.session.close())
 
     @contextlib.contextmanager
     def submit(self, ctx: commands.Context):

--- a/jishaku/features/filesystem.py
+++ b/jishaku/features/filesystem.py
@@ -24,6 +24,7 @@ from jishaku.exception_handling import ReplResponseReactor
 from jishaku.features.baseclass import Feature
 from jishaku.hljs import get_language, guess_file_traits
 from jishaku.paginators import PaginatorInterface, WrappedFilePaginator
+from jishaku.flags import JISHAKU_FORCE_PAGINATOR
 
 
 class FilesystemFeature(Feature):
@@ -68,7 +69,7 @@ class FilesystemFeature(Feature):
 
         try:
             with open(path, "rb") as file:
-                if size < 50_000:  # File "full content" preview limit
+                if size < 50_000 and not ctx.author.is_on_mobile() and not JISHAKU_FORCE_PAGINATOR:  # File "full content" preview limit
                     if line_span:
                         content, *_ = guess_file_traits(file.read())
 
@@ -116,7 +117,7 @@ class FilesystemFeature(Feature):
             if not data:
                 return await ctx.send(f"HTTP response was empty (status code {code}).")
 
-            if len(data) < 50_000:  # File "full content" preview limit
+            if len(data) < 50_000 and not ctx.author.is_on_mobile() and not JISHAKU_FORCE_PAGINATOR:  # File "full content" preview limit
                 # Shallow language detection
                 language = None
 

--- a/jishaku/features/filesystem.py
+++ b/jishaku/features/filesystem.py
@@ -104,7 +104,7 @@ class FilesystemFeature(Feature):
         # remove embed maskers if present
         url = url.lstrip("<").rstrip(">")
 
-        async with ReplResponseReactor(ctx.message):
+        async with ReplResponseReactor(ctx):
             async with aiohttp.ClientSession() as session:
                 async with session.get(url) as response:
                     data = await response.read()

--- a/jishaku/features/invocation.py
+++ b/jishaku/features/invocation.py
@@ -24,6 +24,7 @@ from jishaku.exception_handling import ReplResponseReactor
 from jishaku.features.baseclass import Feature
 from jishaku.models import copy_context_with
 from jishaku.paginators import PaginatorInterface, WrappedPaginator
+from jishaku.flags import JISHAKU_FORCE_PAGINATOR
 
 
 class InvocationFeature(Feature):
@@ -150,7 +151,7 @@ class InvocationFeature(Feature):
         # getsourcelines for some reason returns WITH line endings
         source_text = ''.join(source_lines)
 
-        if len(source_text) < 50_000:  # File "full content" preview limit
+        if len(source_text) < 50_000 and not ctx.author.is_on_mobile() and not JISHAKU_FORCE_PAGINATOR:  # File "full content" preview limit
             await ctx.send(file=discord.File(
                 filename=filename,
                 fp=io.BytesIO(source_text.encode('utf-8'))

--- a/jishaku/features/invocation.py
+++ b/jishaku/features/invocation.py
@@ -119,7 +119,7 @@ class InvocationFeature(Feature):
 
         start = time.perf_counter()
 
-        async with ReplResponseReactor(ctx.message):
+        async with ReplResponseReactor(ctx):
             with self.submit(ctx):
                 await alt_ctx.command.invoke(alt_ctx)
 

--- a/jishaku/features/python.py
+++ b/jishaku/features/python.py
@@ -19,7 +19,7 @@ from discord.ext import commands
 from jishaku.codeblocks import codeblock_converter
 from jishaku.exception_handling import ReplResponseReactor
 from jishaku.features.baseclass import Feature
-from jishaku.flags import JISHAKU_RETAIN, SCOPE_PREFIX
+from jishaku.flags import JISHAKU_RETAIN, SCOPE_PREFIX, JISHAKU_FORCE_PAGINATOR
 from jishaku.functools import AsyncSender
 from jishaku.paginators import PaginatorInterface, WrappedPaginator
 from jishaku.repl import AsyncCodeExecutor, Scope, all_inspections, disassemble, get_var_dict_from_ctx
@@ -115,7 +115,7 @@ class PythonFeature(Feature):
 
                                 send(await ctx.send(result.replace(self.bot.http.token, "[token omitted]")))
 
-                            elif len(result) < 50_000:  # File "full content" preview limit
+                            elif len(result) < 50_000 and not ctx.author.is_on_mobile() and not JISHAKU_FORCE_PAGINATOR:  # File "full content" preview limit
                                 # Discord's desktop and web client now supports an interactive file content
                                 #  display for files encoded in UTF-8.
                                 # Since this avoids escape issues and is more intuitive than pagination for
@@ -169,7 +169,7 @@ class PythonFeature(Feature):
 
                         text = "\n".join(lines)
 
-                        if len(text) < 50_000:  # File "full content" preview limit
+                        if len(text) < 50_000 and not ctx.author.is_on_mobile() and not JISHAKU_FORCE_PAGINATOR:  # File "full content" preview limit
                             send(await ctx.send(file=discord.File(
                                 filename="inspection.prolog",
                                 fp=io.BytesIO(text.encode('utf-8'))
@@ -195,7 +195,7 @@ class PythonFeature(Feature):
         async with ReplResponseReactor(ctx.message):
             text = "\n".join(disassemble(argument.content, arg_dict=arg_dict))
 
-            if len(text) < 50_000:  # File "full content" preview limit
+            if len(text) < 50_000 and not ctx.author.is_on_mobile() and not JISHAKU_FORCE_PAGINATOR:  # File "full content" preview limit
                 await ctx.send(file=discord.File(
                     filename="dis.py",
                     fp=io.BytesIO(text.encode('utf-8'))

--- a/jishaku/features/python.py
+++ b/jishaku/features/python.py
@@ -89,7 +89,7 @@ class PythonFeature(Feature):
         scope = self.scope
 
         try:
-            async with ReplResponseReactor(ctx.message):
+            async with ReplResponseReactor(ctx):
                 with self.submit(ctx):
                     executor = AsyncCodeExecutor(argument.content, scope, arg_dict=arg_dict)
                     async for send, result in AsyncSender(executor):
@@ -151,7 +151,7 @@ class PythonFeature(Feature):
         scope = self.scope
 
         try:
-            async with ReplResponseReactor(ctx.message):
+            async with ReplResponseReactor(ctx):
                 with self.submit(ctx):
                     executor = AsyncCodeExecutor(argument.content, scope, arg_dict=arg_dict)
                     async for send, result in AsyncSender(executor):
@@ -192,7 +192,7 @@ class PythonFeature(Feature):
 
         arg_dict = get_var_dict_from_ctx(ctx, SCOPE_PREFIX)
 
-        async with ReplResponseReactor(ctx.message):
+        async with ReplResponseReactor(ctx):
             text = "\n".join(disassemble(argument.content, arg_dict=arg_dict))
 
             if len(text) < 50_000 and not ctx.author.is_on_mobile() and not JISHAKU_FORCE_PAGINATOR:  # File "full content" preview limit

--- a/jishaku/features/rtfd.py
+++ b/jishaku/features/rtfd.py
@@ -1,0 +1,242 @@
+# -*- coding: utf-8 -*-
+"""
+jishaku.features.rtfd
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The jishaku rtfd-related commands.
+Original credit goes to Danny (Rapptz)
+https://github.com/Rapptz/RoboDanny/blob/rewrite/cogs/api.py
+
+:copyright: (c) 2021 Danny (Rapptz), Clari, Devon (Gorialis) R
+:license: Mozilla Public License 2.0 (https://mozilla.org/MPL/2.0/)
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+"""
+
+import io
+import re
+import os
+import zlib
+import discord
+from discord.ext import commands
+
+from jishaku.features.baseclass import Feature
+
+
+def fuzzyfinder(text, collection, *, key=None, lazy=True):
+    """
+    Fuzzy search from R. Danny's utils
+    """
+    suggestions = []
+    text = str(text)
+    pat = '.*?'.join(map(re.escape, text))
+    regex = re.compile(pat, flags=re.IGNORECASE)
+    for item in collection:
+        to_search = key(item) if key else item
+        r = regex.search(to_search)  # pylint: disable=invalid-name
+        if r:
+            suggestions.append((len(r.group()), r.start(), item))
+
+    def sort_key(tup):
+        if key:
+            return tup[0], tup[1], key(tup[2])
+        return tup
+
+    if lazy:
+        return (z for _, _, z in sorted(suggestions, key=sort_key))
+    else:
+        return [z for _, _, z in sorted(suggestions, key=sort_key)]
+
+
+class SphinxObjectFileReader:
+    """
+    Inspired by Sphinx's InventoryFileReader
+    "Borrowed" from R. Danny for RTFD.
+    """
+    BUFSIZE = 16 * 1024
+
+    def __init__(self, buffer):
+        self.stream = io.BytesIO(buffer)
+
+    def readline(self):  # pylint: disable=missing-function-docstring
+        return self.stream.readline().decode('utf-8')
+
+    def skipline(self):  # pylint: disable=missing-function-docstring
+        self.stream.readline()
+
+    def read_compressed_chunks(self):  # pylint: disable=missing-function-docstring
+        decompressor = zlib.decompressobj()
+        while True:
+            chunk = self.stream.read(self.BUFSIZE)
+            if len(chunk) == 0:
+                break
+            yield decompressor.decompress(chunk)
+        yield decompressor.flush()
+
+    def read_compressed_lines(self):  # pylint: disable=missing-function-docstring
+        buf = b''
+        for chunk in self.read_compressed_chunks():
+            buf += chunk
+            pos = buf.find(b'\n')
+            while pos != -1:
+                yield buf[:pos].decode('utf-8')
+                buf = buf[pos + 1:]
+                pos = buf.find(b'\n')
+
+
+class RTFD(Feature):
+    """
+    Feature containing documentation commands for ease of access, courtesy of R. Danny.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._rtfm_cache = {}
+
+    def parse_object_inv(self, stream, url):  # pylint: disable=missing-function-docstring
+        # key: URL
+        # n.b.: key doesn't have `discord` or `discord.ext.commands` namespaces
+        result = {}
+
+        # first line is version info
+        inv_version = stream.readline().rstrip()
+
+        if inv_version != '# Sphinx inventory version 2':
+            raise RuntimeError('Invalid objects.inv file version.')
+
+        # next line is "# Project: <name>"
+        # then after that is "# Version: <version>"
+        projname = stream.readline().rstrip()[11:]
+        version = stream.readline().rstrip()[11:]  # noqa: F841, pylint: disable=unused-variable
+
+        # next line says if it's a zlib header
+        line = stream.readline()
+        if 'zlib' not in line:
+            raise RuntimeError('Invalid objects.inv file, not z-lib compatible.')
+
+        # This code mostly comes from the Sphinx repository.
+        entry_regex = re.compile(r'(?x)(.+?)\s+(\S*:\S*)\s+(-?\d+)\s+(\S+)\s+(.*)')
+        for line in stream.read_compressed_lines():
+            match = entry_regex.match(line.rstrip())
+            if not match:
+                continue
+
+            name, directive, prio, location, dispname = match.groups()  # pylint: disable=unused-variable
+            domain, _, subdirective = directive.partition(':')
+            if directive == 'py:module' and name in result:
+                # From the Sphinx Repository:
+                # due to a bug in 1.1 and below,
+                # two inventory entries are created
+                # for Python modules, and the first
+                # one is correct
+                continue
+
+            # Most documentation pages have a label
+            if directive == 'std:doc':
+                subdirective = 'label'
+
+            if location.endswith('$'):
+                location = location[:-1] + name
+
+            key = name if dispname == '-' else dispname
+            prefix = f'{subdirective}:' if domain == 'std' else ''
+
+            if projname == 'discord.py':
+                key = key.replace('discord.ext.commands.', '').replace('discord.', '')
+
+            result[f'{prefix}{key}'] = os.path.join(url, location)
+
+        return result
+
+    async def build_rtfm_lookup_table(self, page_types):  # pylint: disable=missing-function-docstring
+        cache = {}
+        for key, page in page_types.items():
+            cache[key] = {}
+            async with self.session.get(page + '/objects.inv') as resp:
+                if resp.status != 200:
+                    raise RuntimeError('Cannot build rtfm lookup table, try again later.')
+
+                stream = SphinxObjectFileReader(await resp.read())
+                cache[key] = self.parse_object_inv(stream, page)
+        self._rtfm_cache = cache
+
+    async def do_rtfm(self, ctx: commands.Context, key, obj):
+        """
+        The actual implementation of the RTFD command.
+        """
+        page_types = {
+            'latest': 'https://discordpy.readthedocs.io/en/latest',
+            'latest-jp': 'https://discordpy.readthedocs.io/ja/latest',
+            'python': 'https://docs.python.org/3',
+            'python-jp': 'https://docs.python.org/ja/3',
+            'master': 'https://discordpy.readthedocs.io/en/master',
+        }
+
+        if obj is None:
+            await ctx.send(page_types[key])
+            return
+
+        if not getattr(self, '_rtfm_cache', {}):
+            await ctx.trigger_typing()
+            await self.build_rtfm_lookup_table(page_types)
+
+        obj = re.sub(r'^(?:discord\.(?:ext\.)?)?(?:commands\.)?(.+)', r'\1', obj)
+
+        if key.startswith('latest'):
+            # point the abc.Messageable types properly:
+            q = obj.lower()  # pylint: disable=invalid-name
+            for name in dir(discord.abc.Messageable):
+                if name[0] == '_':
+                    continue
+                if q == name:
+                    obj = f'abc.Messageable.{name}'
+                    break
+
+        cache = list(self._rtfm_cache.get(key, {}).items())
+
+        matches = fuzzyfinder(obj, cache, key=lambda t: t[0], lazy=False)[:8]
+
+        e = discord.Embed(colour=discord.Colour.blurple())  # pylint: disable=invalid-name
+        if len(matches) == 0:
+            return await ctx.send('Could not find anything. Sorry.')
+
+        e.description = '\n'.join(f'[`{key}`]({url})' for key, url in matches)
+        await ctx.send(embed=e, reference=ctx.message.reference)
+
+    @Feature.Command(parent="jsk", name="rtfd", aliases=['rtfm'], invoke_without_command=True)
+    async def jsk_rtfd(self, ctx: commands.Context, *, obj: str = None):
+        """Gives you a documentation link for a discord.py entity.
+        Events, objects, and functions are all supported through a
+        a cruddy fuzzy algorithm.
+        """
+        await self.do_rtfm(ctx, "latest", obj)
+
+    @Feature.Command(parent="jsk_rtfd", name="jp")
+    async def rtfm_jp(self, ctx: commands.Context, *, obj: str = None):
+        """Gives you a documentation link for a discord.py entity (Japanese)."""
+        await self.do_rtfm(ctx, 'latest-jp', obj)
+
+    @Feature.Command(parent="jsk_rtfd", name='python', aliases=['py'])
+    async def rtfm_python(self, ctx: commands.Context, *, obj: str = None):
+        """Gives you a documentation link for a Python entity."""
+        await self.do_rtfm(ctx, "latest", obj)
+
+    @Feature.Command(parent="jsk_rtfd", name='py-jp', aliases=['py-ja'])
+    async def rtfm_python_jp(self, ctx: commands.Context, *, obj: str = None):
+        """Gives you a documentation link for a Python entity (Japanese)."""
+        await self.do_rtfm(ctx, 'python-jp', obj)
+
+    @Feature.Command(parent="jsk_rtfd", name='master', aliases=['2.0'])
+    async def rtfm_master(self, ctx: commands.Context, *, obj: str = None):
+        """Gives you a documentation link for a discord.py entity (master branch)"""
+        await self.do_rtfm(ctx, 'master', obj)

--- a/jishaku/features/shell.py
+++ b/jishaku/features/shell.py
@@ -34,7 +34,7 @@ class ShellFeature(Feature):
         Execution can be cancelled by closing the paginator.
         """
 
-        async with ReplResponseReactor(ctx.message):
+        async with ReplResponseReactor(ctx):
             with self.submit(ctx):
                 with ShellReader(argument.content) as reader:
                     prefix = "```" + reader.highlight

--- a/jishaku/flags.py
+++ b/jishaku/flags.py
@@ -34,6 +34,10 @@ JISHAKU_RETAIN = enabled("JISHAKU_RETAIN")
 JISHAKU_NO_UNDERSCORE = enabled("JISHAKU_NO_UNDERSCORE")
 SCOPE_PREFIX = '' if JISHAKU_NO_UNDERSCORE else '_'
 
+# Flag to indicate whether or not to always use paginators in commands that now use files
+# as there is no file preview on mobile and some people just like the paginators better.
+JISHAKU_FORCE_PAGINATOR = enabled("JISHAKU_FORCE_PAGINATOR")
+
 # Flag to indicate verbose error tracebacks should be sent to the invoking channel as opposed to via direct message.
 JISHAKU_NO_DM_TRACEBACK = enabled("JISHAKU_NO_DM_TRACEBACK")
 

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ try:
                 COMMIT_BRANCH, ERR = PROCESS.communicate()
 
                 if COMMIT_BRANCH:
-                    VERSION += "." + COMMIT_BRANCH.decode('utf-8').replace('/', '.').strip()
+                    VERSION += "." + re.sub('[^a-zA-Z0-9.]', '.', COMMIT_BRANCH.decode('utf-8').strip())
 
 except FileNotFoundError:
     pass


### PR DESCRIPTION
## Rationale

<!-- What is the reason behind this change? How does implementing it benefit end users or contributors? -->
I added the `rtfd` command, originally from https://github.com/Rapptz/RoboDanny/blob/rewrite/cogs/api.py, to allow developers who use Jishaku to be able to use `rtfd` without having to add it to their own bots.
Also, I made `ReplResponseReactor` use `ctx` instead of `Message` (It still has `self.message` set internally, just changed the destination), to be more compatible with `Context` subclasses, where before it completely bypassed `Context`

## Summary of changes made

<!-- An explanation, in plain English, of your implementation of this change. -->
`rtfd` is for getting quick links to documentation, which is helpful for developers, and this way they don't have to bother with going to a different server or manually adding it to their own bot - it's built into their favorite discord.py tool :)
`ReplResponseReactor` now uses `ctx` instead of `Message` to play nice with a subclass of `commands.Context`

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [x] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
