### PR TITLE
Ctx and intents

### DIFF
--- a/jishaku/exception_handling.py
+++ b/jishaku/exception_handling.py
@@ -88,8 +88,9 @@ class ReactionProcedureTimer:  # pylint: disable=too-few-public-methods
     """
     __slots__ = ('message', 'loop', 'handle', 'raised')
 
-    def __init__(self, message: discord.Message, loop: typing.Optional[asyncio.BaseEventLoop] = None):
-        self.message = message
+    def __init__(self, ctx: commands.Context, loop: typing.Optional[asyncio.BaseEventLoop] = None):
+        self.ctx = ctx
+        self.message = ctx.message
         self.loop = loop or asyncio.get_event_loop()
         self.handle = None
         self.raised = False
@@ -135,11 +136,11 @@ class ReplResponseReactor(ReactionProcedureTimer):  # pylint: disable=too-few-pu
 
         if isinstance(exc_val, (SyntaxError, asyncio.TimeoutError, subprocess.TimeoutExpired)):
             # short traceback, send to channel
-            await send_traceback(self.message.channel, 0, exc_type, exc_val, exc_tb)
+            await send_traceback(self.ctx, 0, exc_type, exc_val, exc_tb)
         else:
             # this traceback likely needs more info, so increase verbosity, and DM it instead.
             await send_traceback(
-                self.message.channel if Flags.NO_DM_TRACEBACK else self.message.author,
+                self.ctx if Flags.NO_DM_TRACEBACK else self.message.author,
                 8, exc_type, exc_val, exc_tb
             )
 

--- a/jishaku/exception_handling.py
+++ b/jishaku/exception_handling.py
@@ -86,7 +86,7 @@ class ReactionProcedureTimer:  # pylint: disable=too-few-public-methods
     """
     Class that reacts to a message based on what happens during its lifetime.
     """
-    __slots__ = ('message', 'loop', 'handle', 'raised')
+    __slots__ = ('ctx', 'message', 'loop', 'handle', 'raised')
 
     def __init__(self, ctx: commands.Context, loop: typing.Optional[asyncio.BaseEventLoop] = None):
         self.ctx = ctx

--- a/jishaku/features/filesystem.py
+++ b/jishaku/features/filesystem.py
@@ -103,7 +103,7 @@ class FilesystemFeature(Feature):
         # remove embed maskers if present
         url = url.lstrip("<").rstrip(">")
 
-        async with ReplResponseReactor(ctx.message):
+        async with ReplResponseReactor(ctx):
             async with aiohttp.ClientSession() as session:
                 async with session.get(url) as response:
                     data = await response.read()

--- a/jishaku/features/invocation.py
+++ b/jishaku/features/invocation.py
@@ -118,7 +118,7 @@ class InvocationFeature(Feature):
 
         start = time.perf_counter()
 
-        async with ReplResponseReactor(ctx.message):
+        async with ReplResponseReactor(ctx):
             with self.submit(ctx):
                 await alt_ctx.command.invoke(alt_ctx)
 

--- a/jishaku/features/management.py
+++ b/jishaku/features/management.py
@@ -131,7 +131,7 @@ class ManagementFeature(Feature):
         }
 
         return await ctx.send(
-            f"Link to invite this bot:\n<https://discordapp.com/oauth2/authorize?{urlencode(query)}>"
+            f"Link to invite this bot:\n<https://discordapp.com/oauth2/authorize?{urlencode(query, safe='+')}>"
         )
 
     @Feature.Command(parent="jsk", name="rtt", aliases=["ping"])

--- a/jishaku/features/python.py
+++ b/jishaku/features/python.py
@@ -139,7 +139,7 @@ class PythonFeature(Feature):
         scope = self.scope
 
         try:
-            async with ReplResponseReactor(ctx.message):
+            async with ReplResponseReactor(ctx):
                 with self.submit(ctx):
                     executor = AsyncCodeExecutor(argument.content, scope, arg_dict=arg_dict)
                     async for send, result in AsyncSender(executor):
@@ -165,7 +165,7 @@ class PythonFeature(Feature):
         scope = self.scope
 
         try:
-            async with ReplResponseReactor(ctx.message):
+            async with ReplResponseReactor(ctx):
                 with self.submit(ctx):
                     executor = AsyncCodeExecutor(argument.content, scope, arg_dict=arg_dict)
                     async for send, result in AsyncSender(executor):
@@ -206,7 +206,7 @@ class PythonFeature(Feature):
 
         arg_dict = get_var_dict_from_ctx(ctx, Flags.SCOPE_PREFIX)
 
-        async with ReplResponseReactor(ctx.message):
+        async with ReplResponseReactor(ctx):
             text = "\n".join(disassemble(argument.content, arg_dict=arg_dict))
 
             if use_file_check(ctx, len(text)):  # File "full content" preview limit

--- a/jishaku/features/shell.py
+++ b/jishaku/features/shell.py
@@ -34,7 +34,7 @@ class ShellFeature(Feature):
         Execution can be cancelled by closing the paginator.
         """
 
-        async with ReplResponseReactor(ctx.message):
+        async with ReplResponseReactor(ctx):
             with self.submit(ctx):
                 with ShellReader(argument.content) as reader:
                     prefix = "```" + reader.highlight

--- a/jishaku/paginators.py
+++ b/jishaku/paginators.py
@@ -155,5 +155,5 @@ def use_file_check(ctx: commands.Context, size: int) -> bool:
     return all([
         size < 50_000,  # Check the text is below the Discord cutoff point;
         not Flags.FORCE_PAGINATOR,  # Check the user hasn't explicitly disabled this;
-        (not ctx.author.is_on_mobile() if ctx.guild else True)  # Ensure the user isn't on mobile
+        (not ctx.author.is_on_mobile() if ctx.guild and ctx.bot.intents.presences else True)  # Ensure the user isn't on mobile
     ])

--- a/jishaku/paginators.py
+++ b/jishaku/paginators.py
@@ -155,5 +155,5 @@ def use_file_check(ctx: commands.Context, size: int) -> bool:
     return all([
         size < 50_000,  # Check the text is below the Discord cutoff point;
         not Flags.FORCE_PAGINATOR,  # Check the user hasn't explicitly disabled this;
-        (not ctx.author.is_on_mobile() if ctx.guild and ctx.bot.intents.presences else True)  # Ensure the user isn't on mobile
+        (not ctx.author.is_on_mobile() if ctx.guild and isinstance(ctx.author, discord.Member) and ctx.bot.intents.presences else True)  # Ensure the user isn't on mobile
     ])


### PR DESCRIPTION
## Rationale
Changing to ctx makes tracebacks work with Context subclasses
Checking intents.presences skips the AttributeError on a message edit where the bot is given a User, and also just doesn't bother with is_on_mobile() if there's no presence intent in the first place
<!-- What is the reason behind this change? How does implementing it benefit end users or contributors? -->

## Summary of changes made
Changed the `message` argument in ReplResponseReactor to `ctx`, and fixed `async with ReplResponseReactor(ctx.message)`s accordingly
Added a ` and ctx.bot.intents.presences` check to the `use_file_check` so it doesn't error on message edit without presences
<!-- An explanation, in plain English, of your implementation of this change. -->

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
