### PR TITLE
Update docs to 2.2.0

### DIFF
--- a/docs/cog.rst
+++ b/docs/cog.rst
@@ -339,27 +339,14 @@ Commands
     If unloading the extension fails, it will be reported with a traceback.
 
 
-.. py:function:: jsk su <member> <command: str>
+.. py:function:: jsk exec [member] [channel] <command: str>
 
-    Runs a command as if it were ran by someone else.
+    Runs a command as if it were ran by someone else and/or in a different channel.
 
     This allows you to test how your bot would react to other users, or perform administrative actions you may have not programmed yourself
     to be able to use by default.
 
-
-.. py:function:: jsk in <channel> <command: str>
-
-    Runs a command as if it were in a different channel.
-
-    Because it matches a `TextChannel`, using this in a guild will only work for other channels in that guild.
-    Cross-server remote commanding can be facilitated by DMing the bot instead.
-
-
-.. py:function:: jsk sudo <command: str>
-
-    Runs a command, ignoring any checks or cooldowns on the command.
-
-    This forces the relevant callbacks to be triggered, and can be used to let you bypass any large cooldowns or conditions you have set.
+    If `exec!` is used instead of `exec`, the command will bypass all checks and cooldowns, directly triggering the callback.
 
 .. py:function:: jsk permtrace <channel> [targets...]
 


### PR DESCRIPTION
## Rationale

This commit updates the documentation to fit the changes in 2.2.0 to clarify why `jsk su`, `jsk sudo`, and `jsk in` don't work anymore, as well as documenting `jsk exec`.

## Summary of changes made

I updated `cog.rst` to fit 2.2.0.

## Checklist

- [ ] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [ ] These changes fix an issue or bug in the module/cog
    - [ ] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [x] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [x] I have proofread my changes for grammar and spelling issues
    - [x] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
