### PR TITLE
Add support for a list of files or embeds

### DIFF
--- a/jishaku/features/python.py
+++ b/jishaku/features/python.py
@@ -12,6 +12,7 @@ The jishaku Python evaluation/execution commands.
 """
 
 import io
+from typing import Iterable
 
 import discord
 from discord.ext import commands
@@ -90,8 +91,14 @@ class PythonFeature(Feature):
         if isinstance(result, discord.File):
             return await ctx.send(file=result)
 
+        if isinstance(result, Iterable) and all(isinstance(obj, discord.File) for obj in result):
+            return await ctx.send(files=result)
+
         if isinstance(result, discord.Embed):
             return await ctx.send(embed=result)
+
+        if isinstance(result, Iterable) and all(isinstance(obj, discord.Embed) for obj in result) and discord.__version__[0] == "2":
+            return await ctx.send(embeds=result)
 
         if isinstance(result, PaginatorInterface):
             return await result.send_to(ctx)


### PR DESCRIPTION
## Rationale

<!-- What is the reason behind this change? How does implementing it benefit end users or contributors? -->
Allows easy sending of multiple embeds in one message without using ctx.send, same way as single embed works.
Same thing with files.
## Summary of changes made

<!-- An explanation, in plain English, of your implementation of this change. -->
I added a check to see if result is an Iterable and if it's all Embeds or Files, and if so it sends all of those.
However, it checks for discord.py 2+ for multiple embeds.
## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [x] These changes add new functionality to the module/cog
    - [ ] These changes fix an issue or bug in the module/cog
    - [ ] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
