### PR TITLE
More slim converters

### DIFF
--- a/jishaku/features/invocation.py
+++ b/jishaku/features/invocation.py
@@ -30,6 +30,7 @@ from jishaku.paginators import PaginatorInterface, WrappedPaginator, use_file_ch
 UserIDConverter = commands.IDConverter[discord.User] if discord.version_info >= (2, 0) else commands.IDConverter
 ChannelIDConverter = commands.IDConverter[discord.TextChannel] if discord.version_info >= (2, 0) else commands.IDConverter
 ThreadIDConverter = commands.IDConverter[discord.Thread] if discord.version_info >= (2, 0) else commands.IDConverter
+Thread = discord.Thread if discord.version_info >= (2, 0) else None
 
 
 class SlimUserConverter(UserIDConverter):  # pylint: disable=too-few-public-methods
@@ -53,7 +54,8 @@ class SlimUserConverter(UserIDConverter):  # pylint: disable=too-few-public-meth
             return result
 
         raise commands.UserNotFound(argument)
-        
+
+
 class SlimChannelConverter(ChannelIDConverter):  # pylint: disable=too-few-public-methods
     """
     Identical to the stock TextChannelConverter, but does not perform plaintext name checks.
@@ -69,14 +71,14 @@ class SlimChannelConverter(ChannelIDConverter):  # pylint: disable=too-few-publi
             if result is not None:
                 return result
         raise commands.ChannelNotFound(argument)
-        
+
 
 class SlimThreadConverter(ThreadIDConverter):  # pylint: disable=too-few-public-methods
     """
     Identical to the stock ThreadConverter, but does not perform plaintext name checks.
     """
 
-    async def convert(self, ctx: commands.Context, argument: str) -> getattr(discord, 'Thread', None):
+    async def convert(self, ctx: commands.Context, argument: str) -> Thread:
         """Converter method"""
         match = self._get_id_match(argument) or re.match(r'<@!?([0-9]{15,20})>$', argument)
 


### PR DESCRIPTION
## Rationale

<!-- What is the reason behind this change? How does implementing it benefit end users or contributors? -->
This avoids channel names conflicting with channel names. It may be an edge case, but I have a channel called `bots` and a command called `bots`, and the Greedy for overrides was eating my command.
## Summary of changes made

<!-- An explanation, in plain English, of your implementation of this change. -->
I basically copied the logic for the SlimUserConverter and applied it to TextChannels and Threads, hopefully with the correct v2 logic.
## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
