### PR TITLE
Fix major bug in jsk voice resume

### DIFF
--- a/jishaku/features/voice.py
+++ b/jishaku/features/voice.py
@@ -173,7 +173,7 @@ class VoiceFeature(Feature):
         Resumes a running audio source, if there is one.
         """
 
-        if await self.playing_check(ctx):
+        if await self.connected_check(ctx):
             return
 
         voice = ctx.guild.voice_client


### PR DESCRIPTION
## Rationale

This PR fixes a major bug in the `voice resume` command. 
The Bug: The command currently checks if the audio source is playing which will always be false when the audio source is paused. This renders the resume command useless. 

![image](https://user-images.githubusercontent.com/61446939/130033472-b4d9bbcd-713c-4af5-8074-35b3a98265c7.png)

## Summary of changes made

Changed `playing_check` to `connected_check` in the `voice resume` command.

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [x] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
