### PR TITLE
add messages intent

### DIFF
--- a/jishaku/features/root_command.py
+++ b/jishaku/features/root_command.py
@@ -152,8 +152,9 @@ class RootCommand(Feature):
         if discord.version_info >= (1, 5, 0):
             presence_intent = f"presence intent is {'enabled' if self.bot.intents.presences else 'disabled'}"
             members_intent = f"members intent is {'enabled' if self.bot.intents.members else 'disabled'}"
+            messages_intent = f"messages intent is {'enabled' if self.bot.intents.messages else 'disabled'}"
 
-            summary.append(f"{message_cache}, {presence_intent} and {members_intent}.")
+            summary.append(f"{message_cache}, {presence_intent}, {members_intent} and {messages_intent}.")
         else:
             guild_subscriptions = f"guild subscriptions are {'enabled' if self.bot._connection.guild_subscriptions else 'disabled'}"
 


### PR DESCRIPTION
## Rationale

<!-- What is the reason behind this change? How does implementing it benefit end users or contributors? -->

I wanna know if my bot has enabled the brand new messages intent without looking into the code.

## Summary of changes made

<!-- An explanation, in plain English, of your implementation of this change. -->

I added the line messages intent, this should be see in the jsk command.

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [x] These changes add new functionality to the module/cog
    - [ ] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [x] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes (no need to do)
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
