### PR TITLE
Add "terminal" as an alias to the shell command

### DIFF
--- a/jishaku/features/shell.py
+++ b/jishaku/features/shell.py
@@ -25,7 +25,7 @@ class ShellFeature(Feature):
     Feature containing the shell-related commands
     """
 
-    @Feature.Command(parent="jsk", name="shell", aliases=["bash", "sh", "powershell", "ps1", "ps", "cmd"])
+    @Feature.Command(parent="jsk", name="shell", aliases=["bash", "sh", "powershell", "ps1", "ps", "cmd", "terminal"])
     async def jsk_shell(self, ctx: commands.Context, *, argument: codeblock_converter):
         """
         Executes statements in the system shell.


### PR DESCRIPTION
## Rationale

It's just another alias for shell, aimed at Mac users who use the Terminal

## Summary of changes made

<!-- An explanation, in plain English, of your implementation of this change. -->

It adds another alias to the `jsk shell` command like `jsk sh`, `jsk powershell` and so on. This one is named `jsk terminal`, and is primarily targeted towards Mac users.

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [x] These changes add new functionality to the module/cog
    - [ ] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase (I don't think this needed testing)
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
