### PR TITLE
Add support for the message_content intent

### DIFF
--- a/jishaku/features/root_command.py
+++ b/jishaku/features/root_command.py
@@ -154,7 +154,7 @@ class RootCommand(Feature):
                 f"presence intent is {'enabled' if self.bot.intents.presences else 'disabled'}",
                 f"members intent is {'enabled' if self.bot.intents.members else 'disabled'}"
             ]
-            
+
             if hasattr(self.bot.intents, "message_content"):
                 # The privileged message content intent is supported
                 intents_info.append(f"message content intent is {'enabled' if self.bot.intents.message_content else 'disabled'}")

--- a/jishaku/features/root_command.py
+++ b/jishaku/features/root_command.py
@@ -159,7 +159,7 @@ class RootCommand(Feature):
                 # The privileged message content intent is supported
                 intents_info.append(f"message content intent is {'enabled' if self.bot.intents.message_content else 'disabled'}")
 
-            summary.append(f"{message_cache}, {", ".join(intents_info[:-1])}, and {intents_info[-1]}.")
+            summary.append(f"{message_cache}, {', '.join(intents_info[:-1])}, and {intents_info[-1]}.")
         else:
             guild_subscriptions = f"guild subscriptions are {'enabled' if self.bot._connection.guild_subscriptions else 'disabled'}"
 

--- a/jishaku/features/root_command.py
+++ b/jishaku/features/root_command.py
@@ -150,10 +150,16 @@ class RootCommand(Feature):
             message_cache = "Message cache is disabled"
 
         if discord.version_info >= (1, 5, 0):
-            presence_intent = f"presence intent is {'enabled' if self.bot.intents.presences else 'disabled'}"
-            members_intent = f"members intent is {'enabled' if self.bot.intents.members else 'disabled'}"
+            intents_info = [
+                f"presence intent is {'enabled' if self.bot.intents.presences else 'disabled'}",
+                f"members intent is {'enabled' if self.bot.intents.members else 'disabled'}"
+            ]
+            
+            if hasattr(self.bot.intents, "message_content"):
+                # The privileged message content intent is supported
+                intents_info.append(f"message content intent is {'enabled' if self.bot.intents.message_content else 'disabled'}")
 
-            summary.append(f"{message_cache}, {presence_intent} and {members_intent}.")
+            summary.append(f"{message_cache}, {", ".join(intents_info[:-1])}, and {intents_info[-1]}.")
         else:
             guild_subscriptions = f"guild subscriptions are {'enabled' if self.bot._connection.guild_subscriptions else 'disabled'}"
 


### PR DESCRIPTION
## Rationale

Privileged intents are listed in the root command, and this adds support for detection of the "message_content" intent, if available. Contrary to #142, this uses the specific message *content* intent (unlike the messages intent it only applies to content, hence the name - and is also privileged). This intent is not supported by discord.py, but as it's a name declared by the API, it can be considered a "standard" name and should be consistent across forks (A "Smaller feature-detection based change" as defined [here](https://github.com/Gorialis/jishaku/issues/141#issuecomment-991947467)). If this feature does not detect support for the message_content intent, it will revert to the old functionality (simply not displaying info on this intent).

I can personally verify that this works with Pycord (already on API v10), and should work with disnake when their [v10 support PR](https://github.com/DisnakeDev/disnake/pull/353) is merged. The same should be true for edpy, when their [v10 PR](https://github.com/iDevision/enhanced-discord.py/pull/162) is merged, and nextcord as well - when [this PR](https://github.com/nextcord/nextcord/pull/457) is merged.

## Summary of changes made

Pretty straightforward, simply adds the message_content intent to the root command. At first I thought this would be useless, but bots can still receive message content without the intent in some cases, so the command can be invoked even if the intent is off.

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [x] These changes add new functionality to the module/cog
    - [ ] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [x] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
