### PR TITLE
Add sync command to allow syncing application commands

### DIFF
--- a/docs/cog.rst
+++ b/docs/cog.rst
@@ -408,3 +408,9 @@ Commands
     The latency for each pass will be shown, as well as an average and standard deviation.
 
     This command will also output the websocket latency.
+
+.. py:function:: jsk sync [guild_ids...]
+
+    Sync global or guild application commands to Discord.
+
+    Should syncing commands to a guild fail the reason will be reported in the output.

--- a/jishaku/features/management.py
+++ b/jishaku/features/management.py
@@ -201,7 +201,7 @@ class ManagementFeature(Feature):
 
         if not guild_ids:
             await self.bot.tree.sync()
-            paginator.add_line("\N{CLOCKWISE RIGHTWARDS AND LEFTWARDS OPEN CIRCLE ARROWS} synced global commands")
+            paginator.add_line("\N{SATELLITE ANTENNA} Synced global commands")
         else:
             for guild_id in guild_ids:
                 try:
@@ -209,7 +209,7 @@ class ManagementFeature(Feature):
                 except discord.HTTPException as exc:
                     paginator.add_line(f"\N{WARNING SIGN} `{guild_id}`: {exc.text}")
                 else:
-                    paginator.add_line(f"\N{CLOCKWISE RIGHTWARDS AND LEFTWARDS OPEN CIRCLE ARROWS} `{guild_id}`")
+                    paginator.add_line(f"\N{SATELLITE ANTENNA} `{guild_id}` Synced guild commands")
 
         for page in paginator.pages:
             await ctx.send(page)

--- a/jishaku/features/management.py
+++ b/jishaku/features/management.py
@@ -190,3 +190,26 @@ class ManagementFeature(Feature):
             # Ignore websocket latencies that are 0 or negative because they usually mean we've got bad heartbeats
             if self.bot.latency > 0.0:
                 websocket_readings.append(self.bot.latency)
+
+    @Feature.Command(parent="jsk", name="sync")
+    async def jsk_sync(self, ctx: commands.Context, *guild_ids: int):
+        """
+        Sync global or guild application commands to Discord.
+        """
+
+        paginator = WrappedPaginator(prefix='', suffix='')
+
+        if not guild_ids:
+            await self.bot.tree.sync()
+            paginator.add_line("\N{CLOCKWISE RIGHTWARDS AND LEFTWARDS OPEN CIRCLE ARROWS} synced global commands")
+        else:
+            for guild_id in guild_ids:
+                try:
+                    await self.bot.tree.sync(guild=discord.Object(guild_id))
+                except discord.HTTPException as exc:
+                    paginator.add_line(f"\N{WARNING SIGN} `{guild_id}`: {exc.text}")
+                else:
+                    paginator.add_line(f"\N{CLOCKWISE RIGHTWARDS AND LEFTWARDS OPEN CIRCLE ARROWS} `{guild_id}`")
+
+        for page in paginator.pages:
+            await ctx.send(page)


### PR DESCRIPTION
## Rationale

Allows users to sync their bots application command tree to Discord without implementing a command themselves.

## Summary of changes made

Adds a command that can sync either global or guild local application commands to Discord.

## Checklist

The tests seem to only fail because they do so on the upstream branch, apologies if I missed a new failure.

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [x] These changes add new functionality to the module/cog
    - [ ] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [x] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
