### PR TITLE
Add `me` as `guild.me` to repl builtin variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ You can also import the module to use the command development utilities.
                     </td>
                 </tr>
                 <tr>
-                    <td><code>_author</code><br><code>_channel</code><br><code>_guild</code><br><code>_message</code><br><code>_msg</code></td>
+                    <td><code>_author</code><br><code>_channel</code><br><code>_guild</code><br><code>_me</code><br><code>_message</code><br><code>_msg</code></td>
                     <td>
                         Shortcuts for attributes on <a href="https://discordpy.readthedocs.io/en/latest/ext/commands/api.html#discord.ext.commands.Context"><code>_ctx</code></a>.
                     </td>

--- a/jishaku/repl/repl_builtins.py
+++ b/jishaku/repl/repl_builtins.py
@@ -87,6 +87,7 @@ def get_var_dict_from_ctx(ctx: commands.Context, prefix: str = '_'):
         'find': discord.utils.find,
         'get': discord.utils.get,
         'guild': ctx.guild,
+        'me': ctx.guild.me,
         'http_get_bytes': http_get_bytes,
         'http_get_json': http_get_json,
         'http_post_bytes': http_post_bytes,


### PR DESCRIPTION
## Rationale

This change is a QoL feature so users have to type less to access the `me` variable.

## Summary of changes made

This adds a new repl builtin variable `me`, which is a shortcut for the `guild.me` attribute that represents the bot in a member form.

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [x] These changes add new functionality to the module/cog
    - [ ] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase (testing not needed AFAIK)
    - [ ] I have tested these changes against the CI/CD test suite
    - [x] I have updated the documentation to reflect these changes (only the README)
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [x] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [x] I have proofread my changes for grammar and spelling issues
    - [x] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
