### PR TITLE
Remove information about the end of discord.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,21 +27,6 @@ a debugging and utility extension for discord.py bots
 
 ***
 
-> <h3><b>⚠️ Warning</b></h3>
->
-> As of the 27th of August 2021, [discord.py has ceased development](https://gist.github.com/Rapptz/4a2f62751b9600a31a0d3c78100287f1).
->
-> Jishaku will continue to be maintained targeting both the PyPI version and the [latest git revision](https://github.com/Rapptz/discord.py/tree/45d498c1b76deaf3b394d17ccf56112fa691d160) as of the archive, until at least the date of the slash command mandate (currently speculated to be around April 2022).
->
-> As all trusted contributors have rejected continuing the library, I do not have enough trust in any forks to target those instead. The existing forks are handled by inexperienced developers, and I figure this will continue to be the case in the future, as all of the developers experienced enough to carry the torch do not want to maintain the library for similar reasons to Danny himself.
->
-> However, if you personally decide that you wish to use a fork, I will allow Jishaku to honor your decision by removing the `discord.py` package requirement. **This means, from now on, installing jishaku will not automatically handle installing `discord.py`, you must choose a version to use yourself**. Any fork that you use must be compatible with the original (in that it supplies the `discord` module and its namespaces).
->
-> When April 2022 comes, I will make a decision at the time as to whether I want to continue maintaining Jishaku. I still enjoy making and maintaining bots, but implementing Jishaku under the philosophies I have defined so far will likely be impossible under the new slash commands, and I don't really want to compromise my work for the sake of appeasing a company that doesn't care for its developers.
->
-> I hope you've found Jishaku useful, and hopefully it will get to live on in one way or another.
-
-
 jishaku is an extension for bot developers that enables rapid prototyping, experimentation, and debugging of features for bots.
 
 One of jishaku's core philosophies is to be dynamic and easy-to-use. Here's the two step install:


### PR DESCRIPTION
## Rationale

Users who access the Jishaku Repository are misled that discord.py is no longer maintained

## Summary of changes made

Removed information about Ending support for discord.py

## Checklist

- [x] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [x] I have proofread my changes for grammar and spelling issues
    - [x] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
