### PR TITLE
Display number of commands synced

### DIFF
--- a/jishaku/features/management.py
+++ b/jishaku/features/management.py
@@ -200,16 +200,16 @@ class ManagementFeature(Feature):
         paginator = WrappedPaginator(prefix='', suffix='')
 
         if not guild_ids:
-            await self.bot.tree.sync()
-            paginator.add_line("\N{SATELLITE ANTENNA} Synced global commands")
+            synced = await self.bot.tree.sync()
+            paginator.add_line(f"\N{SATELLITE ANTENNA} Synced {len(synced)} global commands")
         else:
             for guild_id in guild_ids:
                 try:
-                    await self.bot.tree.sync(guild=discord.Object(guild_id))
+                    synced = await self.bot.tree.sync(guild=discord.Object(guild_id))
                 except discord.HTTPException as exc:
                     paginator.add_line(f"\N{WARNING SIGN} `{guild_id}`: {exc.text}")
                 else:
-                    paginator.add_line(f"\N{SATELLITE ANTENNA} `{guild_id}` Synced guild commands")
+                    paginator.add_line(f"\N{SATELLITE ANTENNA} `{guild_id}` Synced {len(synced)} guild commands")
 
         for page in paginator.pages:
             await ctx.send(page)


### PR DESCRIPTION
## Rationale

The reasoning, so that the end users know how many commands got synced. Could be handy to debug issues like the commands not being registered to that guild, etc.

<!-- What is the reason behind this change? How does implementing it benefit end users or contributors? -->

## Summary of changes made

`tree.sync` returns a list of commands synced, so `len()` it and display it.

![image](https://user-images.githubusercontent.com/13399568/161393165-2a3f5930-3979-4941-b2d8-f296e7eae2fb.png)

<!-- An explanation, in plain English, of your implementation of this change. -->

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [x] These changes add new functionality to the module/cog
    - [ ] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
