### PR TITLE
Fix math domain error

### DIFF
--- a/jishaku/features/root_command.py
+++ b/jishaku/features/root_command.py
@@ -43,7 +43,10 @@ def natural_size(size_in_bytes: int):
     """
     units = ('B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB')
 
-    power = int(math.log(size_in_bytes, 1024))
+    try:
+        power = int(math.log(size_in_bytes, 1024))
+    except ValueError:
+        power = 0
 
     return f"{size_in_bytes / (1024 ** power):.2f} {units[power]}"
 


### PR DESCRIPTION
when memory bytes was't gotten collectly

## Rationale

When memory bytes was't gotten collectly, the `jsk` command wouldn't run.
```py
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/discord/ext/commands/core.py", line 168, in wrapped
    ret = await coro(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/jishaku/features/root_command.py", line 102, in jsk
    f"{natural_size(mem.uss)} of which unique to this process.")
  File "/usr/local/lib/python3.9/dist-packages/jishaku/features/root_command.py", line 46, in natural_size
    power = int(math.log(size_in_bytes, 1024))
ValueError: math domain error
```
I checked `mem.uss` and returned `0`.
Maybe because the bot is runnning on WSL, but I want to run jsk command.
So I created a pull request.
I'm Japanese, so my English may look clumsy.

## Summary of changes made

Only put `try` and `except ValueError: power=0`.

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
