### PR TITLE
Fix asyncpg.Pool usage

### DIFF
--- a/jishaku/features/sql.py
+++ b/jishaku/features/sql.py
@@ -107,15 +107,15 @@ try:
 except ImportError:
     pass
 else:
-    @adapter(asyncpg.Connection, asyncpg.Pool)
-    class AsyncpgConnectionAdapter(Adapter[typing.Union[asyncpg.Connection, asyncpg.Pool]]):
-        def __init__(self, connection: typing.Union[asyncpg.Connection, asyncpg.Pool]):
+    @adapter(asyncpg.Connection, asyncpg.pool.Pool)
+    class AsyncpgConnectionAdapter(Adapter[typing.Union[asyncpg.Connection, asyncpg.pool.Pool]]):
+        def __init__(self, connection: typing.Union[asyncpg.Connection, asyncpg.pool.Pool]):
             super().__init__(connection)
             self.connection: asyncpg.Connection = None  # type: ignore
 
         @contextlib.asynccontextmanager
         async def use(self):
-            if isinstance(self.connector, asyncpg.Pool):
+            if isinstance(self.connector, asyncpg.pool.Pool):
                 async with self.connector.acquire() as connection:  # type: ignore
                     self.connection = connection  # type: ignore
                     yield


### PR DESCRIPTION
## Rationale

There is an error in the importing of `Pool` from asyncpg as it is asyncpg.pool.Pool.

Currently an error is produced
```py
dagbot    | Traceback (most recent call last):
dagbot    |   File "/usr/local/lib/python3.8/site-packages/discord/ext/commands/bot.py", line 917, in _load_from_module_spec
dagbot    |     spec.loader.exec_module(lib)  # type: ignore
dagbot    |   File "<frozen importlib._bootstrap_external>", line 783, in exec_module
dagbot    |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
dagbot    |   File "/usr/local/lib/python3.8/site-packages/jishaku/__init__.py", line 15, in <module>
dagbot    |     from jishaku.cog import *  # noqa: F401
dagbot    |   File "/usr/local/lib/python3.8/site-packages/jishaku/cog.py", line 27, in <module>
dagbot    |     from jishaku.features.sql import SQLFeature
dagbot    |   File "/usr/local/lib/python3.8/site-packages/jishaku/features/sql.py", line 110, in <module>
dagbot    |     @adapter(asyncpg.Connection, asyncpg.Pool)
dagbot    | AttributeError: module 'asyncpg' has no attribute 'Pool'
dagbot    | 
dagbot    | The above exception was the direct cause of the following exception:
dagbot    | 
dagbot    | Traceback (most recent call last):
dagbot    |   File "/usr/local/lib/python3.8/runpy.py", line 194, in _run_module_as_main
dagbot    |     return _run_code(code, main_globals, None,
dagbot    |   File "/usr/local/lib/python3.8/runpy.py", line 87, in _run_code
dagbot    |     exec(code, run_globals)
dagbot    |   File "/dagbot/__main__.py", line 20, in <module>
dagbot    |     asyncio.run(start_bot())
dagbot    |   File "/usr/local/lib/python3.8/asyncio/runners.py", line 44, in run
dagbot    |     return loop.run_until_complete(main)
dagbot    |   File "/usr/local/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
dagbot    |     return future.result()
dagbot    |   File "/dagbot/__main__.py", line 9, in start_bot
dagbot    |     await dagbot.startdagbot()
dagbot    |   File "/dagbot/bot.py", line 147, in startdagbot
dagbot    |     await self.load_extensionsa()
dagbot    |   File "/dagbot/bot.py", line 110, in load_extensionsa
dagbot    |     await self.load_extension("jishaku")
dagbot    |   File "/usr/local/lib/python3.8/site-packages/discord/ext/commands/bot.py", line 995, in load_extension
dagbot    |     await self._load_from_module_spec(spec, name)
dagbot    |   File "/usr/local/lib/python3.8/site-packages/discord/ext/commands/bot.py", line 920, in _load_from_module_spec
dagbot    |     raise errors.ExtensionFailed(key, e) from e
dagbot    | discord.ext.commands.errors.ExtensionFailed: Extension 'jishaku' raised an error: AttributeError: module 'asyncpg' has no attribute 'Pool'
```

## Summary of changes made

Simply switched the import. https://magicstack.github.io/asyncpg/current/api/index.html?highlight=pool#asyncpg.pool.Pool

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [x] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
