### PR TITLE
Fix UnboundLocalError for bad sql queries

### DIFF
--- a/jishaku/features/sql.py
+++ b/jishaku/features/sql.py
@@ -304,10 +304,14 @@ class SQLFeature(Feature):
         if adapter_shim is None:
             return await ctx.send("No SQL adapter could be found on this bot.")
 
+        output = None
         async with adapter_shim.use():
             async with ReplResponseReactor(ctx.message):
                 with self.submit(ctx):
                     output = await adapter_shim.fetchrow(query)
+
+        if output is None:
+            return
 
         if not output:
             return await ctx.reply("No results produced.")
@@ -337,10 +341,14 @@ class SQLFeature(Feature):
         if adapter_shim is None:
             return await ctx.send("No SQL adapter could be found on this bot.")
 
+        output = None
         async with adapter_shim.use():
             async with ReplResponseReactor(ctx.message):
                 with self.submit(ctx):
                     output = await adapter_shim.fetch(query)
+
+        if output is None:
+            return
 
         if not output:
             return await ctx.reply("No results produced.")
@@ -384,10 +392,14 @@ class SQLFeature(Feature):
         if adapter_shim is None:
             return await ctx.send("No SQL adapter could be found on this bot.")
 
+        output = None
         async with adapter_shim.use():
             async with ReplResponseReactor(ctx.message):
                 with self.submit(ctx):
                     output = await adapter_shim.execute(query)
+
+        if output is None:
+            return
 
         await ctx.reply(content=output)
 
@@ -402,10 +414,14 @@ class SQLFeature(Feature):
         if adapter_shim is None:
             return await ctx.send("No SQL adapter could be found on this bot.")
 
+        output = None
         async with adapter_shim.use():
             async with ReplResponseReactor(ctx.message):
                 with self.submit(ctx):
                     output = await adapter_shim.table_summary(query)
+
+        if output is None:
+            return
 
         if not output:
             return await ctx.reply("No results produced.")


### PR DESCRIPTION
## Rationale

<!-- What is the reason behind this change? How does implementing it benefit end users or contributors? -->
Using `jsk sql` commands with a query that would raise an error such as `seelect 5` would raise 2 errors, one for the bad query and an UnboundLocalError for output.

## Summary of changes made

<!-- An explanation, in plain English, of your implementation of this change. -->
start with output=None then check if it's still None after executing
## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
