### PR TITLE
Fix guild and user pluralization

### DIFF
--- a/jishaku/features/root_command.py
+++ b/jishaku/features/root_command.py
@@ -102,8 +102,8 @@ class RootCommand(Feature):
                     "to query process information."
                 )
                 summary.append("")  # blank line
-        s_for_guilds = "s" if len(self.bot.guilds) == 0 or len(self.bot.guilds) == 1 else ""
-        s_for_users = "s" if len(self.bot.users) == 0 or len(self.bot.users) == 1 else ""
+        s_for_guilds = "" if len(self.bot.guilds) == 1 else "s"
+        s_for_users = "" if len(self.bot.users) == 1 else "s"
         cache_summary = f"{len(self.bot.guilds)} guild{s_for_guilds} and {len(self.bot.users)} user{s_for_users}"
 
         # Show shard settings to summary


### PR DESCRIPTION
## Rationale

'user' and 'guild' in the root Jishaku command will only be plural if the amount is either 0 or 1. They should be plural only if the amount is not 1.

## Summary of changes made

Instead of pluralizing the word if the given amount is either 0 or 1, singularize it only when the given amount is exactly 1.

## Checklist

- [ ] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
