### PR TITLE
Fix `jsk_sql_select` command registration error

### DIFF
--- a/jishaku/features/sql.py
+++ b/jishaku/features/sql.py
@@ -373,7 +373,7 @@ class SQLFeature(Feature):
             interface = PaginatorInterface(ctx.bot, paginator, owner=ctx.author)
             await interface.send_to(ctx)
 
-    @Feature.Command(parent="jsk_sql", name="select", aliases=['SELECT'])
+    @Feature.Command(parent="jsk_sql", name="select")
     async def jsk_sql_select(self, ctx: ContextA, *, query: str):
         """
         Shortcut for 'jsk sql fetch select'.


### PR DESCRIPTION
## Rationale

<!-- What is the reason behind this change? How does implementing it benefit end users or contributors? -->
maybe there's something else at play here, but when `Bot case_insensitive` is `True`, trying to register `SELECT` as an alias for `select` throws an error saying it's already registered. I tried removing the alias and it fixed itself which leads me to believe that this is the issue.

i would guess there's no error when bot _is_ case sensitive because then it registers as a different command name

## Summary of changes made

<!-- An explanation, in plain English, of your implementation of this change. -->
simply remove the `aliases=['SELECT']` from `jsk_sql_select`

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
