### PR TITLE
replace pkg_resources with importlib.metadata

### DIFF
--- a/jishaku/meta.py
+++ b/jishaku/meta.py
@@ -13,7 +13,6 @@ Meta information about jishaku.
 
 import typing
 
-import pkg_resources
 
 __all__ = (
     '__author__',
@@ -43,6 +42,3 @@ __docformat__ = 'restructuredtext en'
 __license__ = 'MIT'
 __title__ = 'jishaku'
 __version__ = '.'.join(map(str, (version_info.major, version_info.minor, version_info.micro)))
-
-# This ensures that when jishaku is reloaded, pkg_resources requeries it to provide correct version info
-pkg_resources.working_set.by_key.pop('jishaku', None)  # type: ignore

--- a/jishaku/meta.py
+++ b/jishaku/meta.py
@@ -13,7 +13,6 @@ Meta information about jishaku.
 
 import typing
 
-
 __all__ = (
     '__author__',
     '__copyright__',

--- a/jishaku/modules.py
+++ b/jishaku/modules.py
@@ -13,8 +13,8 @@ Functions for managing and searching modules.
 
 import pathlib
 import typing
+import importlib.metadata
 
-import pkg_resources
 from braceexpand import braceexpand
 from discord.ext import commands
 
@@ -88,8 +88,9 @@ def package_version(package_name: str) -> typing.Optional[str]:
     """
 
     try:
-        return pkg_resources.get_distribution(package_name).version
-    except (pkg_resources.DistributionNotFound, AttributeError):
+        return importlib.metadata.version(package_name)
+    # ValueError if package_name was empty
+    except (importlib.metadata.PackageNotFoundError, ValueError):
         return None
 
 

--- a/jishaku/modules.py
+++ b/jishaku/modules.py
@@ -11,9 +11,9 @@ Functions for managing and searching modules.
 
 """
 
+import importlib.metadata
 import pathlib
 import typing
-import importlib.metadata
 
 from braceexpand import braceexpand
 from discord.ext import commands


### PR DESCRIPTION
## Rationale

<!-- What is the reason behind this change? How does implementing it benefit end users or contributors? -->

setuptools (pkg_resources) is no longer installed in venvs by default starting in 3.12 as per https://github.com/python/cpython/issues/95299

so code using it doesn't work anymore

## Summary of changes made

<!-- An explanation, in plain English, of your implementation of this change. -->

I replaced the usages of pkg_resources with importlib.metadata

before in meta.py there was some code that removed the jishaku module from it's internal cache; this is no longer needed when using importlib.metadata

another solution to this might be to add setuptools to jishaku's dependencies

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
