### PR TITLE
Add jishaku.__main__ to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,11 @@ setup(
     python_requires='>=3.10.0',
 
     extras_require=EXTRA_REQUIRES,
+    entry_points={
+        'console_scripts': [
+            'jishaku = jishaku.__main__:entrypoint',
+        ],
+    },
 
     download_url=f'https://github.com/Gorialis/jishaku/archive/{version}.tar.gz',
 


### PR DESCRIPTION
## Rationale

Made this change to accurately reflect the entry points of jishaku so toolings such as Nix can accurately detect the console scripts for better packaging.

<!-- What is the reason behind this change? How does implementing it benefit end users or contributors? -->

This simply gives more accurate information about what this package has to offer. There is no *real* benefit here, just consistency.

## Summary of changes made

<!-- An explanation, in plain English, of your implementation of this change. -->

This adds `jishaku.__main__` to `entry_points.console_scripts` inside `setup()`.

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [ ] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [ ] These changes fix an issue or bug in the module/cog
    - [ ] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
