### PR TITLE
Add support to `jsk sync` for clearing application commands

### DIFF
--- a/jishaku/features/management.py
+++ b/jishaku/features/management.py
@@ -212,38 +212,50 @@ class ManagementFeature(Feature):
         paginator = commands.Paginator(prefix='', suffix='')
 
         guilds_set: typing.Set[typing.Optional[int]] = set()
+        clear_guilds_set: typing.Set[typing.Optional[int]] = set()
         for target in targets:
-            if target == '$':
-                guilds_set.add(None)
+            active_set = guilds_set
+            if target[0] == '-':
+                active_set = clear_guilds_set
+                target = target[1:]
+            if target == '' or target == '$':
+                active_set.add(None)
             elif target == '*':
-                guilds_set |= set(self.bot.tree._guild_commands.keys())  # type: ignore  # pylint: disable=protected-access
+                active_set |= set(self.bot.tree._guild_commands.keys())  # type: ignore  # pylint: disable=protected-access
             elif target == '.':
                 if ctx.guild:
-                    guilds_set.add(ctx.guild.id)
+                    active_set.add(ctx.guild.id)
                 else:
                     await ctx.send("Can't sync guild commands without guild information")
                     return
             else:
                 try:
-                    guilds_set.add(int(target))
+                    active_set.add(int(target))
                 except ValueError as error:
                     raise commands.BadArgument(f"{target} is not a valid guild ID") from error
 
         if not targets:
             guilds_set.add(None)
 
-        guilds: typing.List[typing.Optional[int]] = list(guilds_set)
-        guilds.sort(key=lambda g: (g is not None, g))
+        guilds: typing.List[typing.Tuple[typing.Optional[int], bool]] = []
+        for guild in guilds_set:
+            guilds.append((guild, False))
+        for guild in clear_guilds_set:
+            guilds.append((guild, True))
+        guilds.sort(key=lambda g: (g[0] is not None, g))
 
-        for guild in guilds:
+        for guild, clear in guilds:
             slash_commands = self.bot.tree._get_all_commands(  # type: ignore  # pylint: disable=protected-access
                 guild=discord.Object(guild) if guild else None
             )
-            translator = getattr(self.bot.tree, 'translator', None)
-            if translator:
-                payload = [await command.get_translated_payload(translator) for command in slash_commands]
+            if clear:
+                payload = []
             else:
-                payload = [command.to_dict() for command in slash_commands]
+                translator = getattr(self.bot.tree, 'translator', None)
+                if translator:
+                    payload = [await command.get_translated_payload(translator) for command in slash_commands]
+                else:
+                    payload = [command.to_dict() for command in slash_commands]
 
             try:
                 if guild is None:


### PR DESCRIPTION
Usage remains largely the same, but prefixing a target with `-` will switch to upserting an empty payload
`-` alone or `-$` can both be used to clear global commands
`-.`, `-*`, or `-{guild_id}` all simply clear the commands for the expected target

## Rationale

<!-- What is the reason behind this change? How does implementing it benefit end users or contributors? -->
Currently, if I want to clear my commands (my use case, btw, is clearing from the beta bot so they don't interfere with the public bot), I have to manually type `bot.tree.clear_commands(guild=guild/None)`, so this just makes it easier to wipe commands from a locale.

On a similar note, I wanted to also ask - thoughts on a way to replicate ```py
CommandTree.copy_global_to(guild=guild)
await CommandTree.sync(guild=guild)
```
with `jsk sync`? I was thinking something like `+{target}` could handle that for guild ids/`*`/`.`, and be ignored for `$`?

## Summary of changes made

<!-- An explanation, in plain English, of your implementation of this change. -->
I created a second set that holds the guilds to be cleared, and changed the cleaned guilds list to be a tuple of [id, clear?], then loop through and set `payload` to an empty list when clear is True

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [x] These changes add new functionality to the module/cog
    - [ ] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
