### PR TITLE
Update sync command to work in discord.py 2.4

### DIFF
--- a/jishaku/features/management.py
+++ b/jishaku/features/management.py
@@ -241,7 +241,7 @@ class ManagementFeature(Feature):
             )
             translator = getattr(self.bot.tree, 'translator', None)
             needs_dpy_2_4_signature_changes = discord.version_info.major >= 2 and discord.version_info.minor >= 4
-            
+
             if needs_dpy_2_4_signature_changes:
                 if translator:
                     payload = [await command.get_translated_payload(self.bot.tree, translator) for command in slash_commands]
@@ -252,7 +252,6 @@ class ManagementFeature(Feature):
                     payload = [await command.get_translated_payload(translator) for command in slash_commands]
                 else:
                     payload = [command.to_dict() for command in slash_commands]
-
 
             try:
                 if guild is None:

--- a/jishaku/features/management.py
+++ b/jishaku/features/management.py
@@ -240,10 +240,19 @@ class ManagementFeature(Feature):
                 guild=discord.Object(guild) if guild else None
             )
             translator = getattr(self.bot.tree, 'translator', None)
-            if translator:
-                payload = [await command.get_translated_payload(translator) for command in slash_commands]
+            needs_dpy_2_4_signature_changes = discord.version_info.major >= 2 and discord.version_info.minor >= 4
+            
+            if needs_dpy_2_4_signature_changes:
+                if translator:
+                    payload = [await command.get_translated_payload(self.bot.tree, translator) for command in slash_commands]
+                else:
+                    payload = [command.to_dict(self.bot.tree) for command in slash_commands]
             else:
-                payload = [command.to_dict() for command in slash_commands]
+                if translator:
+                    payload = [await command.get_translated_payload(translator) for command in slash_commands]
+                else:
+                    payload = [command.to_dict() for command in slash_commands]
+
 
             try:
                 if guild is None:


### PR DESCRIPTION
## Rationale

<!-- What is the reason behind this change? How does implementing it benefit end users or contributors? -->

discord.py 2.4 updates the `get_translated_payload` and `to_dict` method signatures for application commands, making the CommandTree a required parameter.

## Summary of changes made

<!-- An explanation, in plain English, of your implementation of this change. -->
Support the new function signatures without breaking backwards compatibility with discord.py <= 2.3

Supersedes #230 

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [x] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
