### PR TITLE
Implements #229

### DIFF
--- a/jishaku/features/management.py
+++ b/jishaku/features/management.py
@@ -30,6 +30,9 @@ from jishaku.types import ContextA
 
 
 class SyncFlags(commands.FlagConverter, prefix="", delimiter=""):
+    """
+    A flag converter for the sync command.
+    """
     targets: typing.Tuple[str, ...] = commands.flag(positional=True)
     clear: typing.List[int] = commands.flag(aliases=["-"], default=[])
 

--- a/jishaku/features/management.py
+++ b/jishaku/features/management.py
@@ -234,7 +234,7 @@ class ManagementFeature(Feature):
                 except ValueError as error:
                     raise commands.BadArgument(f"{target} is not a valid guild ID") from error
 
-        if not flags.targets:
+        if not (flags.targets or flags.clear):
             guilds_set.add(None)
 
         guilds: typing.List[typing.Optional[int]] = list(guilds_set)


### PR DESCRIPTION
## Rationale

Through the new positional parameter in flags, it's possible to keep the traditional syntax yet being able to add the removing commands functionality, allowing us to remove each of them in a -1 -2 -3 fashion. It allows users to remove the commands from specific guilds as proposed originally in #229.

## Summary of changes made

Instead of using a greedy str parameter, I've changed it for a flag converter which utilizes the greedy str within itself alongside a new "-" parameter which removes the slash commands from those guilds.

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [X] This PR changes the jishaku module/cog codebase
    - [X] These changes add new functionality to the module/cog
    - [ ] These changes fix an issue or bug in the module/cog
    - [X] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
