### PR TITLE
fix: use annotationlib for Flags mapping in 3.14

### DIFF
--- a/jishaku/flags.py
+++ b/jishaku/flags.py
@@ -98,11 +98,6 @@ class FlagMeta(type):
     ):
         attrs['flag_map'] = {}
 
-        # https://docs.python.org/3/library/annotationlib.html#annotationlib-metaclass
-        # From 3.14 onwards, __annotations__ is a data descriptor that is
-        # not included in the class namespace. Instead, the compiler defines
-        # an __annotate__ attribute at compile time which can be called to
-        # evaluate annotations.
         if '__annotations__' in attrs:
             annotations = attrs['__annotations__']
 
@@ -114,6 +109,10 @@ class FlagMeta(type):
                 )
 
         elif sys.version_info >= (3, 14):
+            # https://docs.python.org/3/library/annotationlib.html#annotationlib-metaclass
+            # From 3.14 onwards, __annotations__ is a data descriptor not included
+            # in the class namespace. Instead, the compiler defines an __annotate__
+            # function we can call to evaluate annotations.
             import annotationlib
 
             annotate = annotationlib.get_annotate_from_class_namespace(attrs)


### PR DESCRIPTION
## Rationale

This PR fixes #246 by using annotationlib in 3.14+ to evaluate annotations in FlagMeta.

## Summary of changes made

A 3.14 conditional block is added to call `annotationlib.get_annotate_from_class_namespace()` and `annotationlib.call_annotate_function()` to evaluate Flags's annotations.

Related documentation: https://docs.python.org/3/library/annotationlib.html#using-annotations-in-a-metaclass

To be honest, I haven't really followed the developments behind [PEP 649](https://peps.python.org/pep-0649/) so I'm not sure if this is the best solution, but the test suite passes in 3.14 and 3.8 :)

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [ ] I have tested that these changes work on a production bot codebase
    - [x] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
