### PR TITLE
`rerun` command to re-execute commands from replied messages (with intact content, attachments, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,11 +211,16 @@ You can also import the module to use the command development utilities.
         </td>
         <td>
             <h4>&gt; <code>jishaku exec [member and/or channel...] &lt;command string&gt;</code></h4>
+            <h4>&gt; <code>jishaku rerun [member and/or channel...] [message]</code></h4>
             <h4>&gt; <code>jishaku debug &lt;command string&gt;</code></h4>
             <h4>&gt; <code>jishaku repeat &lt;times&gt; &lt;command string&gt;</code></h4>
             These commands serve as command control for other commands.
             <br><br>
             <code>jishaku exec</code> allows you to execute a command as another user, in another channel, or both. Using aliases with a postfix exclamation mark (such as <code>jsk exec! ...</code>) executes the command bypassing checks and cooldowns.
+            <br><br>
+            <code>jishaku rerun</code> allows you to re-run an already ran command (either by replying to the message or by passing in the message arg), optionally as another user, in another channel, or both. Using aliases with a postfix exclamation mark (such as <code>jsk rerun! ...</code>) re-runs the command bypassing checks and cooldowns.
+            <br><br>
+            Useful for re-running commands for debugging purposes without having to copy-paste content or resend attachments and other contextual entities.
             <br><br>
             <code>jishaku debug</code> executes a command with an exception wrapper and a timer. This allows you to quickly get feedback on reproducable command errors and slowdowns.
             <br><br>

--- a/docs/cog.rst
+++ b/docs/cog.rst
@@ -363,6 +363,19 @@ Commands
 
     If `exec!` is used instead of `exec`, the command will bypass all checks and cooldowns, directly triggering the callback.
 
+
+.. py:function:: jsk rerun [member_and_or_channel...] [message]
+
+    Re-runs an already ran command, optionally as if it were ran by someone else and/or in a different channel.
+
+    This allows you to rerun commands commands from a replied message or the message argument (e.g. url, id, etc. to be converted by commands.MessageConverter). Useful for re-executing perhaps after making changes (to the code, message's content, etc), without having to copy-paste content or resend attachments and/or other contextual entities, optionally as another user or in another channel.
+
+    You can provide a channel to redirect command location, a user to redirect command origin, or both.
+
+    If `rerun!` is used instead of `rerun`, the command will bypass all checks and cooldowns, directly triggering the callback.
+
+    This command piggybacks off of the `jsk exec` command so it has the same overrides and fundamental behaviors.
+
 .. py:function:: jsk permtrace <channel> [targets...]
 
     Emulates Discord's permission calculation system to create a breakdown of where certain permissions for a member come from.

--- a/jishaku/features/invocation.py
+++ b/jishaku/features/invocation.py
@@ -139,7 +139,7 @@ class InvocationFeature(Feature):
         await alt_ctx.command.invoke(alt_ctx)
         return
 
-    @Feature.Command(parent="jsk", name="rerun", aliases=["rr", "rerun!", "rr!"])
+    @Feature.Command(parent="jsk", name="rerun", aliases=["rr", "rerun!", "rr!", "re", "re!"])
     async def jsk_rerun(
         self,
         ctx: ContextT,

--- a/jishaku/features/invocation.py
+++ b/jishaku/features/invocation.py
@@ -165,10 +165,17 @@ class InvocationFeature(Feature):
         if not isinstance(target, discord.Message):
             return await ctx.send("Reply to a message or provide a message link.")
 
+        # Setting the target's author to the current author and then overriding it back as the original
+        # target's author later in exec feels redundant but we don't want to run the exec command itself
+        # as the target's author, just in case.
+        msg_ctx = await self.bot.get_context(target, cls=ctx.__class__)
+        msg_ctx = await copy_context_with(msg_ctx, author=ctx.author)
+
+        # If no user overrides were provided, default to the original message's author
         if not any(isinstance(o, (discord.Member, discord.User)) for o in overrides):
             overrides = [target.author, *overrides]
 
-        await self.jsk_override(ctx, overrides, command_string=target.content.lstrip(ctx.prefix or ""))
+        await self.jsk_override(msg_ctx, overrides, command_string=target.content.lstrip(ctx.prefix or ""))
 
     @Feature.Command(parent="jsk", name="repeat")
     async def jsk_repeat(self, ctx: ContextT, times: int, *, command_string: str):

--- a/jishaku/features/invocation.py
+++ b/jishaku/features/invocation.py
@@ -105,9 +105,9 @@ class InvocationFeature(Feature):
             return
 
         for override in overrides:
-            if isinstance(override, discord.User):
+            if isinstance(override, (discord.User, discord.Member)):
                 # This is a user
-                if ctx.guild:
+                if isinstance(override, discord.User) and ctx.guild:
                     # Try to upgrade to a Member instance
                     # This used to be done by a Union converter, but doing it like this makes
                     #  the command more compatible with chaining, e.g. `jsk in .. jsk su ..`

--- a/jishaku/features/invocation.py
+++ b/jishaku/features/invocation.py
@@ -139,6 +139,32 @@ class InvocationFeature(Feature):
         await alt_ctx.command.invoke(alt_ctx)
         return
 
+    @Feature.Command(parent="jsk", name="rerun", aliases=["rr", "rerun!", "rr!"])
+    async def jsk_rerun(
+        self,
+        ctx: ContextT,
+        overrides: commands.Greedy[OVERRIDE_SIGNATURE],
+        *,
+        message: typing.Optional[commands.MessageConverter] = None,
+    ):
+        """
+        Re-run a command from a replied message or message link, optionally with a different user, channel or thread and/or bypassing checks and cooldowns
+
+        Users will try to resolve to a Member, but will use a User if it can't find one.
+
+        Piggybacks off of `jsk override` so it accepts all the same overrides and has the same fundamental behaviours.
+        """
+
+        target = message or (ctx.message.reference and ctx.message.reference.resolved)
+
+        if not isinstance(target, discord.Message):
+            return await ctx.send("Reply to a message or provide a message link.")
+
+        if not any(isinstance(o, (discord.Member, discord.User)) for o in overrides):
+            overrides = [target.author, *overrides]
+
+        await self.jsk_override(ctx, overrides, command_string=target.content.lstrip(ctx.prefix or ""))
+
     @Feature.Command(parent="jsk", name="repeat")
     async def jsk_repeat(self, ctx: ContextT, times: int, *, command_string: str):
         """

--- a/jishaku/features/invocation.py
+++ b/jishaku/features/invocation.py
@@ -152,7 +152,7 @@ class InvocationFeature(Feature):
 
         Users will try to resolve to a Member, but will use a User if it can't find one.
 
-        Piggybacks off of `jsk override` so it accepts all the same overrides and has the same fundamental behaviours.
+        Piggybacks off of `jsk override` so it accepts all the same overrides and has the same fundamental behaviors.
         """
 
         target = message or (ctx.message.reference and ctx.message.reference.resolved)

--- a/jishaku/features/invocation.py
+++ b/jishaku/features/invocation.py
@@ -155,7 +155,12 @@ class InvocationFeature(Feature):
         Piggybacks off of `jsk override` so it accepts all the same overrides and has the same fundamental behaviors.
         """
 
-        target = message or (ctx.message.reference and ctx.message.reference.resolved)
+        target = message
+        if target is None:
+            ref = ctx.message.reference
+            if ref is not None:
+                with contextlib.suppress(commands.MessageNotFound):
+                    target = await commands.MessageConverter().convert(ctx, ref.jump_url)
 
         if not isinstance(target, discord.Message):
             return await ctx.send("Reply to a message or provide a message link.")

--- a/jishaku/features/invocation.py
+++ b/jishaku/features/invocation.py
@@ -170,6 +170,7 @@ class InvocationFeature(Feature):
         # as the target's author, just in case.
         msg_ctx = await self.bot.get_context(target, cls=ctx.__class__)
         msg_ctx = await copy_context_with(msg_ctx, author=ctx.author)
+        msg_ctx.invoked_with = ctx.invoked_with
 
         # Prevent infinite recursions by prohibiting rerunning rerun commands
         if msg_ctx.command and msg_ctx.view:


### PR DESCRIPTION
## Rationale

I was programming a command that takes attachments and I found myself having to resend attachments and copy the same contents over and over again as I made changes to the code. This became super tedious and I thought about making a command on my bot to do this but then realize it's actually really useful and I could create a PR for it

There are other really useful use-cases too, for example if you have a bunch of jsk scripts pinned in a channel like me you can easily re-run them with just the message ID without having to copy-paste (or resend any attachments). It's also really nice if you had nitro before when you sent a command but no longer have the extra characters to resend it again.

Aside from attachments it's just really nice to have a way to rerun a command, perhaps even as a different user or in a different channel, without having to copy its contents every time. It piggybacks off of the `jsk exec` command so the overrides and behaviors are the same.

It could also be useful for running commands with embeds (if you override a bot's message) to test stuff

## Summary of changes made

- Added the `jsk rerun` command to rerun a command from a message without needing to copy-paste or resend attachments/other contextual entities. Similar syntax to the `jsk exec` command, allows overriding and bypassing.
  - the message can be replied to when running the command or passed through the optional `message` argument (url, id, etc.) that MessageConverter converts
  - i don't like the method i used to see if the target message is another rerun command invocation to prevent circular reruns. but after hours of trying different things i could not find another way to get the subcommand before the ctx is invoked upon.
- Added documentation for the command.
- Fixed a bug in Jishaku preventing member mentions from working in the `jsk override` command
  - was gonna make another PR for this but the `rerun` command implementation depends on this to work

scroll for demo!

## Checklist
- [x] This PR changes the jishaku module/cog codebase
    - [x] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [x] I have tested these changes against the CI/CD test suite
    - [x] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [x] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [x] I have proofread my changes for grammar and spelling issues
    - [x] I have tested that any changes regarding Markdown/RST syntax result in a well formed document

## Demonstration
### 1. unit tests
<img width="1734" height="1032" alt="Screenshot 2026-01-27 235001" src="https://github.com/user-attachments/assets/8fb52a4a-1853-4614-8902-e7d7d55dcd9d" />

### 2. fixed long time bug preventing member mentions in the exec command (old vs new)
<img width="1561" height="643" alt="image" src="https://github.com/user-attachments/assets/b82b6ae4-c588-4f62-adc4-a14b355dd599" />

### 3. rerunning a command by replying without having to resend attachment
<img width="1218" height="938" alt="image" src="https://github.com/user-attachments/assets/978df47a-c013-410c-98fe-9caef9db0366" />

### 3. rerunning command by message id (same channel)
<img width="985" height="541" alt="image" src="https://github.com/user-attachments/assets/7cb7fbb9-7039-4059-9da3-7d069214347e" />

### 4. bypassing checks (also rerunning by channelid-messageid pair)
<img width="1564" height="1176" alt="image" src="https://github.com/user-attachments/assets/d2cdca26-15a4-489b-aaea-4de4bbd5b84e" />

### 5. here i edited an old message and reran the command with the same attachments
<img width="1085" height="297" alt="image" src="https://github.com/user-attachments/assets/a94f065c-9604-42fc-b503-a41c735e3dee" />
