### PR TITLE
Fix typo in the rerun command documentation

### DIFF
--- a/docs/cog.rst
+++ b/docs/cog.rst
@@ -368,7 +368,7 @@ Commands
 
     Re-runs an already ran command, optionally as if it were ran by someone else and/or in a different channel.
 
-    This allows you to rerun commands commands from a replied message or the message argument (e.g. url, id, etc. to be converted by commands.MessageConverter). Useful for re-executing perhaps after making changes (to the code, message's content, etc), without having to copy-paste content or resend attachments and/or other contextual entities, optionally as another user or in another channel.
+    This allows you to rerun commands from a replied message or the message argument (e.g. url, id, etc. to be converted by commands.MessageConverter). Useful for re-executing perhaps after making changes (to the code, message's content, etc), without having to copy-paste content or resend attachments and/or other contextual entities, optionally as another user or in another channel.
 
     You can provide a channel to redirect command location, a user to redirect command origin, or both.
 


### PR DESCRIPTION
## Rationale

Fixed a typo in the new `rerun` command documentation. I checked like 5 times before and after creating the PR but still ended up with a typo my bad 😭

## Summary of changes made

Removed duplicate word 'commands' in the `rerun` command documentation.

## Checklist

- [ ] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [ ] These changes fix an issue or bug in the module/cog
    - [ ] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [x] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [x] I have proofread my changes for grammar and spelling issues
    - [x] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
